### PR TITLE
Update sdk for 0.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ vpath %.proto $(PROTOS_PATH)
 all: system-check libdapr.so
 
 libdapr.so : ./src/dapr/proto/common/v1/common.pb.o ./src/dapr/proto/runtime/v1/dapr.pb.o ./src/dapr/proto/runtime/v1/dapr.grpc.pb.o ./src/dapr/proto/runtime/v1/appcallback.pb.o ./src/dapr/proto/runtime/v1/appcallback.grpc.pb.o
-	-mkdir ./out
+	-mkdir -p ./out
 	$(CXX) -shared -Wl,-soname,libdapr.so.0 -o ./out/libdapr.0.2.0.so ./src/dapr/proto/runtime/v1/*.o ./src/dapr/proto/common/v1/*.o
 
 %.o : %.cc

--- a/dapr/proto/runtime/v1/appcallback.proto
+++ b/dapr/proto/runtime/v1/appcallback.proto
@@ -74,6 +74,18 @@ message TopicEventRequest {
 
 // TopicEventResponse is response from app on published message
 message TopicEventResponse {
+  // TopicEventResponseStatus allows apps to have finer control over handling of the message.
+  enum TopicEventResponseStatus {
+    // SUCCESS is the default behavior: message is acknowledged and not retried or logged.
+    SUCCESS = 0;
+    // RETRY status signals Dapr to retry the message as part of an expected scenario (no warning is logged).
+    RETRY = 1;
+    // DROP status signals Dapr to drop the message as part of an unexpected scenario (warning is logged).
+    DROP = 2;
+  }
+
+  // The list of output bindings.
+  TopicEventResponseStatus status = 1;
 }
 
 // BindingEventRequest represents input bindings event.

--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -64,6 +64,9 @@ message GetStateRequest {
 
   // The read consistency of the state store.
   common.v1.StateOptions.StateConsistency consistency = 3;
+
+  // The metadata which will be sent to state store components.
+  map<string,string> metadata = 4;
 }
 
 // GetBulkStateRequest is the message to get a list of key-value states from specific state store.
@@ -76,6 +79,9 @@ message GetBulkStateRequest {
 
   // The number of parallel operations executed on the state store for a get operation.
   int32 parallelism = 3;
+
+  // The metadata which will be sent to state store components.
+  map<string,string> metadata = 4;
 }
 
 // GetBulkStateResponse is the response conveying the list of state values.
@@ -96,6 +102,9 @@ message BulkStateItem {
   // The entity tag which represents the specific version of data.
   // ETag format is defined by the corresponding data store.
   string etag = 3;
+
+  // The error that was returned from the state store in case of a failed get operation.
+  string error = 4;
 }
 
 // GetStateResponse is the response conveying the state value and etag.
@@ -123,6 +132,9 @@ message DeleteStateRequest {
   // State operation options which includes concurrency/
   // consistency/retry_policy.
   common.v1.StateOptions options = 4;
+
+  // The metadata which will be sent to state store components.
+  map<string,string> metadata = 5;
 }
 
 // SaveStateRequest is the message to save multiple states into state store.

--- a/src/dapr/proto/runtime/v1/appcallback.pb.cc
+++ b/src/dapr/proto/runtime/v1/appcallback.pb.cc
@@ -222,7 +222,7 @@ void InitDefaults() {
 }
 
 ::google::protobuf::Metadata file_level_metadata[9];
-const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[1];
+const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[2];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -243,6 +243,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventResponse, status_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse, _has_bits_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -303,13 +304,13 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::runtime::v1::TopicEventRequest)},
   { 13, -1, sizeof(::dapr::proto::runtime::v1::TopicEventResponse)},
-  { 18, 25, sizeof(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse)},
-  { 27, -1, sizeof(::dapr::proto::runtime::v1::BindingEventRequest)},
-  { 35, -1, sizeof(::dapr::proto::runtime::v1::BindingEventResponse)},
-  { 45, -1, sizeof(::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse)},
-  { 51, 58, sizeof(::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse)},
-  { 60, -1, sizeof(::dapr::proto::runtime::v1::TopicSubscription)},
-  { 68, -1, sizeof(::dapr::proto::runtime::v1::ListInputBindingsResponse)},
+  { 19, 26, sizeof(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse)},
+  { 28, -1, sizeof(::dapr::proto::runtime::v1::BindingEventRequest)},
+  { 36, -1, sizeof(::dapr::proto::runtime::v1::BindingEventResponse)},
+  { 46, -1, sizeof(::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse)},
+  { 52, 59, sizeof(::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse)},
+  { 61, -1, sizeof(::dapr::proto::runtime::v1::TopicSubscription)},
+  { 69, -1, sizeof(::dapr::proto::runtime::v1::ListInputBindingsResponse)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -352,46 +353,50 @@ void AddDescriptorsImpl() {
       "(\t\022\016\n\006source\030\002 \001(\t\022\014\n\004type\030\003 \001(\t\022\024\n\014spec"
       "_version\030\004 \001(\t\022\031\n\021data_content_type\030\005 \001("
       "\t\022\014\n\004data\030\007 \001(\014\022\r\n\005topic\030\006 \001(\t\022\023\n\013pubsub"
-      "_name\030\010 \001(\t\"\024\n\022TopicEventResponse\"\256\001\n\023Bi"
-      "ndingEventRequest\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030"
-      "\002 \001(\014\022J\n\010metadata\030\003 \003(\01328.dapr.proto.run"
-      "time.v1.BindingEventRequest.MetadataEntr"
-      "y\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
-      "\030\002 \001(\t:\0028\001\"\210\002\n\024BindingEventResponse\022\022\n\ns"
-      "tore_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037.dapr.p"
-      "roto.common.v1.StateItem\022\n\n\002to\030\003 \003(\t\022\014\n\004"
-      "data\030\004 \001(\014\022X\n\013concurrency\030\005 \001(\0162C.dapr.p"
-      "roto.runtime.v1.BindingEventResponse.Bin"
-      "dingEventConcurrency\"7\n\027BindingEventConc"
-      "urrency\022\016\n\nSEQUENTIAL\020\000\022\014\n\010PARALLEL\020\001\"a\n"
-      "\036ListTopicSubscriptionsResponse\022\?\n\rsubsc"
-      "riptions\030\001 \003(\0132(.dapr.proto.runtime.v1.T"
-      "opicSubscription\"\262\001\n\021TopicSubscription\022\023"
-      "\n\013pubsub_name\030\001 \001(\t\022\r\n\005topic\030\002 \001(\t\022H\n\010me"
-      "tadata\030\003 \003(\01326.dapr.proto.runtime.v1.Top"
-      "icSubscription.MetadataEntry\032/\n\rMetadata"
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"-\n"
-      "\031ListInputBindingsResponse\022\020\n\010bindings\030\001"
-      " \003(\t2\206\004\n\013AppCallback\022W\n\010OnInvoke\022#.dapr."
-      "proto.common.v1.InvokeRequest\032$.dapr.pro"
-      "to.common.v1.InvokeResponse\"\000\022i\n\026ListTop"
-      "icSubscriptions\022\026.google.protobuf.Empty\032"
-      "5.dapr.proto.runtime.v1.ListTopicSubscri"
-      "ptionsResponse\"\000\022e\n\014OnTopicEvent\022(.dapr."
-      "proto.runtime.v1.TopicEventRequest\032).dap"
-      "r.proto.runtime.v1.TopicEventResponse\"\000\022"
-      "_\n\021ListInputBindings\022\026.google.protobuf.E"
-      "mpty\0320.dapr.proto.runtime.v1.ListInputBi"
-      "ndingsResponse\"\000\022k\n\016OnBindingEvent\022*.dap"
-      "r.proto.runtime.v1.BindingEventRequest\032+"
-      ".dapr.proto.runtime.v1.BindingEventRespo"
-      "nse\"\000By\n\nio.dapr.v1B\025DaprAppCallbackProt"
-      "osZ1github.com/dapr/dapr/pkg/proto/runti"
-      "me/v1;runtime\252\002 Dapr.AppCallback.Autogen"
-      ".Grpc.v1b\006proto3"
+      "_name\030\010 \001(\t\"\246\001\n\022TopicEventResponse\022R\n\006st"
+      "atus\030\001 \001(\0162B.dapr.proto.runtime.v1.Topic"
+      "EventResponse.TopicEventResponseStatus\"<"
+      "\n\030TopicEventResponseStatus\022\013\n\007SUCCESS\020\000\022"
+      "\t\n\005RETRY\020\001\022\010\n\004DROP\020\002\"\256\001\n\023BindingEventReq"
+      "uest\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022J\n\010meta"
+      "data\030\003 \003(\01328.dapr.proto.runtime.v1.Bindi"
+      "ngEventRequest.MetadataEntry\032/\n\rMetadata"
+      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\210\002"
+      "\n\024BindingEventResponse\022\022\n\nstore_name\030\001 \001"
+      "(\t\022/\n\006states\030\002 \003(\0132\037.dapr.proto.common.v"
+      "1.StateItem\022\n\n\002to\030\003 \003(\t\022\014\n\004data\030\004 \001(\014\022X\n"
+      "\013concurrency\030\005 \001(\0162C.dapr.proto.runtime."
+      "v1.BindingEventResponse.BindingEventConc"
+      "urrency\"7\n\027BindingEventConcurrency\022\016\n\nSE"
+      "QUENTIAL\020\000\022\014\n\010PARALLEL\020\001\"a\n\036ListTopicSub"
+      "scriptionsResponse\022\?\n\rsubscriptions\030\001 \003("
+      "\0132(.dapr.proto.runtime.v1.TopicSubscript"
+      "ion\"\262\001\n\021TopicSubscription\022\023\n\013pubsub_name"
+      "\030\001 \001(\t\022\r\n\005topic\030\002 \001(\t\022H\n\010metadata\030\003 \003(\0132"
+      "6.dapr.proto.runtime.v1.TopicSubscriptio"
+      "n.MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030"
+      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"-\n\031ListInputBin"
+      "dingsResponse\022\020\n\010bindings\030\001 \003(\t2\206\004\n\013AppC"
+      "allback\022W\n\010OnInvoke\022#.dapr.proto.common."
+      "v1.InvokeRequest\032$.dapr.proto.common.v1."
+      "InvokeResponse\"\000\022i\n\026ListTopicSubscriptio"
+      "ns\022\026.google.protobuf.Empty\0325.dapr.proto."
+      "runtime.v1.ListTopicSubscriptionsRespons"
+      "e\"\000\022e\n\014OnTopicEvent\022(.dapr.proto.runtime"
+      ".v1.TopicEventRequest\032).dapr.proto.runti"
+      "me.v1.TopicEventResponse\"\000\022_\n\021ListInputB"
+      "indings\022\026.google.protobuf.Empty\0320.dapr.p"
+      "roto.runtime.v1.ListInputBindingsRespons"
+      "e\"\000\022k\n\016OnBindingEvent\022*.dapr.proto.runti"
+      "me.v1.BindingEventRequest\032+.dapr.proto.r"
+      "untime.v1.BindingEventResponse\"\000By\n\nio.d"
+      "apr.v1B\025DaprAppCallbackProtosZ1github.co"
+      "m/dapr/dapr/pkg/proto/runtime/v1;runtime"
+      "\252\002 Dapr.AppCallback.Autogen.Grpc.v1b\006pro"
+      "to3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 1736);
+      descriptor, 1883);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/appcallback.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fempty_2eproto::AddDescriptors();
@@ -413,9 +418,32 @@ namespace dapr {
 namespace proto {
 namespace runtime {
 namespace v1 {
-const ::google::protobuf::EnumDescriptor* BindingEventResponse_BindingEventConcurrency_descriptor() {
+const ::google::protobuf::EnumDescriptor* TopicEventResponse_TopicEventResponseStatus_descriptor() {
   protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
   return protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_enum_descriptors[0];
+}
+bool TopicEventResponse_TopicEventResponseStatus_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse::SUCCESS;
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse::RETRY;
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse::DROP;
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse::TopicEventResponseStatus_MIN;
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse::TopicEventResponseStatus_MAX;
+const int TopicEventResponse::TopicEventResponseStatus_ARRAYSIZE;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+const ::google::protobuf::EnumDescriptor* BindingEventResponse_BindingEventConcurrency_descriptor() {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
+  return protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_enum_descriptors[1];
 }
 bool BindingEventResponse_BindingEventConcurrency_IsValid(int value) {
   switch (value) {
@@ -1076,6 +1104,7 @@ void TopicEventRequest::InternalSwap(TopicEventRequest* other) {
 void TopicEventResponse::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int TopicEventResponse::kStatusFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 TopicEventResponse::TopicEventResponse()
@@ -1089,10 +1118,12 @@ TopicEventResponse::TopicEventResponse(const TopicEventResponse& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  status_ = from.status_;
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.TopicEventResponse)
 }
 
 void TopicEventResponse::SharedCtor() {
+  status_ = 0;
 }
 
 TopicEventResponse::~TopicEventResponse() {
@@ -1123,6 +1154,7 @@ void TopicEventResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  status_ = 0;
   _internal_metadata_.Clear();
 }
 
@@ -1135,12 +1167,32 @@ bool TopicEventResponse::MergePartialFromCodedStream(
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          set_status(static_cast< ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus >(value));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
     }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.TopicEventResponse)
@@ -1157,6 +1209,12 @@ void TopicEventResponse::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  // .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+  if (this->status() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      1, this->status(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -1170,6 +1228,12 @@ void TopicEventResponse::SerializeWithCachedSizes(
   // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.TopicEventResponse)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
+
+  // .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+  if (this->status() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      1, this->status(), target);
+  }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
@@ -1188,6 +1252,12 @@ size_t TopicEventResponse::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+  if (this->status() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::EnumSize(this->status());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -1215,6 +1285,9 @@ void TopicEventResponse::MergeFrom(const TopicEventResponse& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.status() != 0) {
+    set_status(from.status());
+  }
 }
 
 void TopicEventResponse::CopyFrom(const ::google::protobuf::Message& from) {
@@ -1241,6 +1314,7 @@ void TopicEventResponse::Swap(TopicEventResponse* other) {
 }
 void TopicEventResponse::InternalSwap(TopicEventResponse* other) {
   using std::swap;
+  swap(status_, other->status_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 

--- a/src/dapr/proto/runtime/v1/appcallback.pb.h
+++ b/src/dapr/proto/runtime/v1/appcallback.pb.h
@@ -104,6 +104,28 @@ namespace proto {
 namespace runtime {
 namespace v1 {
 
+enum TopicEventResponse_TopicEventResponseStatus {
+  TopicEventResponse_TopicEventResponseStatus_SUCCESS = 0,
+  TopicEventResponse_TopicEventResponseStatus_RETRY = 1,
+  TopicEventResponse_TopicEventResponseStatus_DROP = 2,
+  TopicEventResponse_TopicEventResponseStatus_TopicEventResponse_TopicEventResponseStatus_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
+  TopicEventResponse_TopicEventResponseStatus_TopicEventResponse_TopicEventResponseStatus_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
+};
+bool TopicEventResponse_TopicEventResponseStatus_IsValid(int value);
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_MIN = TopicEventResponse_TopicEventResponseStatus_SUCCESS;
+const TopicEventResponse_TopicEventResponseStatus TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_MAX = TopicEventResponse_TopicEventResponseStatus_DROP;
+const int TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_ARRAYSIZE = TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* TopicEventResponse_TopicEventResponseStatus_descriptor();
+inline const ::std::string& TopicEventResponse_TopicEventResponseStatus_Name(TopicEventResponse_TopicEventResponseStatus value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    TopicEventResponse_TopicEventResponseStatus_descriptor(), value);
+}
+inline bool TopicEventResponse_TopicEventResponseStatus_Parse(
+    const ::std::string& name, TopicEventResponse_TopicEventResponseStatus* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<TopicEventResponse_TopicEventResponseStatus>(
+    TopicEventResponse_TopicEventResponseStatus_descriptor(), name, value);
+}
 enum BindingEventResponse_BindingEventConcurrency {
   BindingEventResponse_BindingEventConcurrency_SEQUENTIAL = 0,
   BindingEventResponse_BindingEventConcurrency_PARALLEL = 1,
@@ -428,12 +450,47 @@ class TopicEventResponse : public ::google::protobuf::Message /* @@protoc_insert
 
   // nested types ----------------------------------------------------
 
+  typedef TopicEventResponse_TopicEventResponseStatus TopicEventResponseStatus;
+  static const TopicEventResponseStatus SUCCESS =
+    TopicEventResponse_TopicEventResponseStatus_SUCCESS;
+  static const TopicEventResponseStatus RETRY =
+    TopicEventResponse_TopicEventResponseStatus_RETRY;
+  static const TopicEventResponseStatus DROP =
+    TopicEventResponse_TopicEventResponseStatus_DROP;
+  static inline bool TopicEventResponseStatus_IsValid(int value) {
+    return TopicEventResponse_TopicEventResponseStatus_IsValid(value);
+  }
+  static const TopicEventResponseStatus TopicEventResponseStatus_MIN =
+    TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_MIN;
+  static const TopicEventResponseStatus TopicEventResponseStatus_MAX =
+    TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_MAX;
+  static const int TopicEventResponseStatus_ARRAYSIZE =
+    TopicEventResponse_TopicEventResponseStatus_TopicEventResponseStatus_ARRAYSIZE;
+  static inline const ::google::protobuf::EnumDescriptor*
+  TopicEventResponseStatus_descriptor() {
+    return TopicEventResponse_TopicEventResponseStatus_descriptor();
+  }
+  static inline const ::std::string& TopicEventResponseStatus_Name(TopicEventResponseStatus value) {
+    return TopicEventResponse_TopicEventResponseStatus_Name(value);
+  }
+  static inline bool TopicEventResponseStatus_Parse(const ::std::string& name,
+      TopicEventResponseStatus* value) {
+    return TopicEventResponse_TopicEventResponseStatus_Parse(name, value);
+  }
+
   // accessors -------------------------------------------------------
+
+  // .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+  void clear_status();
+  static const int kStatusFieldNumber = 1;
+  ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus status() const;
+  void set_status(::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus value);
 
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.TopicEventResponse)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  int status_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::TableStruct;
 };
@@ -1625,6 +1682,20 @@ inline void TopicEventRequest::set_allocated_pubsub_name(::std::string* pubsub_n
 
 // TopicEventResponse
 
+// .dapr.proto.runtime.v1.TopicEventResponse.TopicEventResponseStatus status = 1;
+inline void TopicEventResponse::clear_status() {
+  status_ = 0;
+}
+inline ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus TopicEventResponse::status() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicEventResponse.status)
+  return static_cast< ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus >(status_);
+}
+inline void TopicEventResponse::set_status(::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus value) {
+  
+  status_ = value;
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.TopicEventResponse.status)
+}
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -2242,6 +2313,11 @@ ListInputBindingsResponse::mutable_bindings() {
 namespace google {
 namespace protobuf {
 
+template <> struct is_proto_enum< ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus>() {
+  return ::dapr::proto::runtime::v1::TopicEventResponse_TopicEventResponseStatus_descriptor();
+}
 template <> struct is_proto_enum< ::dapr::proto::runtime::v1::BindingEventResponse_BindingEventConcurrency> : ::std::true_type {};
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::dapr::proto::runtime::v1::BindingEventResponse_BindingEventConcurrency>() {

--- a/src/dapr/proto/runtime/v1/dapr.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.pb.cc
@@ -26,9 +26,12 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2ep
 }  // namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto
 namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto {
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_BulkStateItem;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_DeleteStateRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_ExecuteStateTransactionRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretResponse_DataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetStateRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingResponse_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_TransactionalStateOperation;
@@ -42,11 +45,21 @@ class InvokeServiceRequestDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<InvokeServiceRequest>
       _instance;
 } _InvokeServiceRequest_default_instance_;
+class GetStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetStateRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _GetStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class GetStateRequestDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<GetStateRequest>
       _instance;
 } _GetStateRequest_default_instance_;
+class GetBulkStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetBulkStateRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _GetBulkStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class GetBulkStateRequestDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<GetBulkStateRequest>
@@ -67,6 +80,11 @@ class GetStateResponseDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<GetStateResponse>
       _instance;
 } _GetStateResponse_default_instance_;
+class DeleteStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<DeleteStateRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class DeleteStateRequestDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<DeleteStateRequest>
@@ -157,6 +175,19 @@ static void InitDefaultsInvokeServiceRequest() {
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsInvokeServiceRequest}, {
       &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_InvokeRequest.base,}};
 
+static void InitDefaultsGetStateRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetStateRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_GetStateRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetStateRequest_MetadataEntry_DoNotUse}, {}};
+
 static void InitDefaultsGetStateRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -168,8 +199,22 @@ static void InitDefaultsGetStateRequest() {
   ::dapr::proto::runtime::v1::GetStateRequest::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GetStateRequest =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetStateRequest}, {}};
+::google::protobuf::internal::SCCInfo<1> scc_info_GetStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetStateRequest}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetStateRequest_MetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsGetBulkStateRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetBulkStateRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetBulkStateRequest_MetadataEntry_DoNotUse}, {}};
 
 static void InitDefaultsGetBulkStateRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -182,8 +227,9 @@ static void InitDefaultsGetBulkStateRequest() {
   ::dapr::proto::runtime::v1::GetBulkStateRequest::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkStateRequest =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetBulkStateRequest}, {}};
+::google::protobuf::internal::SCCInfo<1> scc_info_GetBulkStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetBulkStateRequest}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse.base,}};
 
 static void InitDefaultsGetBulkStateResponse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -228,6 +274,19 @@ static void InitDefaultsGetStateResponse() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_GetStateResponse =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetStateResponse}, {}};
 
+static void InitDefaultsDeleteStateRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_DeleteStateRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsDeleteStateRequest_MetadataEntry_DoNotUse}, {}};
+
 static void InitDefaultsDeleteStateRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -239,9 +298,10 @@ static void InitDefaultsDeleteStateRequest() {
   ::dapr::proto::runtime::v1::DeleteStateRequest::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<1> scc_info_DeleteStateRequest =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsDeleteStateRequest}, {
-      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateOptions.base,}};
+::google::protobuf::internal::SCCInfo<2> scc_info_DeleteStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 2, InitDefaultsDeleteStateRequest}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateOptions.base,
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_DeleteStateRequest_MetadataEntry_DoNotUse.base,}};
 
 static void InitDefaultsSaveStateRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -430,11 +490,14 @@ static void InitDefaultsExecuteStateTransactionRequest() {
 
 void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeServiceRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetStateRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetStateRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkStateResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_BulkStateItem.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetStateResponse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_DeleteStateRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_DeleteStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_SaveStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_PublishEventRequest.base);
@@ -451,7 +514,7 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_ExecuteStateTransactionRequest.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[20];
+::google::protobuf::Metadata file_level_metadata[23];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -461,6 +524,15 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::InvokeServiceRequest, id_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::InvokeServiceRequest, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -469,6 +541,16 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest, store_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest, key_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest, consistency_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateRequest, metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -477,6 +559,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest, store_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest, keys_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest, parallelism_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateRequest, metadata_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkStateResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -491,6 +574,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BulkStateItem, key_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BulkStateItem, data_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BulkStateItem, etag_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::BulkStateItem, error_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -498,6 +582,15 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateResponse, data_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetStateResponse, etag_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -507,6 +600,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, key_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, etag_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, options_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, metadata_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SaveStateRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -615,34 +709,40 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::runtime::v1::InvokeServiceRequest)},
-  { 7, -1, sizeof(::dapr::proto::runtime::v1::GetStateRequest)},
-  { 15, -1, sizeof(::dapr::proto::runtime::v1::GetBulkStateRequest)},
-  { 23, -1, sizeof(::dapr::proto::runtime::v1::GetBulkStateResponse)},
-  { 29, -1, sizeof(::dapr::proto::runtime::v1::BulkStateItem)},
-  { 37, -1, sizeof(::dapr::proto::runtime::v1::GetStateResponse)},
-  { 44, -1, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest)},
-  { 53, -1, sizeof(::dapr::proto::runtime::v1::SaveStateRequest)},
-  { 60, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
-  { 68, 75, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
-  { 77, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
-  { 86, 93, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
-  { 95, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
-  { 102, 109, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
-  { 111, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
-  { 119, 126, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
-  { 128, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
-  { 134, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
-  { 141, 148, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
-  { 150, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
+  { 7, 14, sizeof(::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse)},
+  { 16, -1, sizeof(::dapr::proto::runtime::v1::GetStateRequest)},
+  { 25, 32, sizeof(::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse)},
+  { 34, -1, sizeof(::dapr::proto::runtime::v1::GetBulkStateRequest)},
+  { 43, -1, sizeof(::dapr::proto::runtime::v1::GetBulkStateResponse)},
+  { 49, -1, sizeof(::dapr::proto::runtime::v1::BulkStateItem)},
+  { 58, -1, sizeof(::dapr::proto::runtime::v1::GetStateResponse)},
+  { 65, 72, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse)},
+  { 74, -1, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest)},
+  { 84, -1, sizeof(::dapr::proto::runtime::v1::SaveStateRequest)},
+  { 91, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
+  { 99, 106, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
+  { 108, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
+  { 117, 124, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
+  { 126, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
+  { 133, 140, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
+  { 142, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
+  { 150, 157, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
+  { 159, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
+  { 165, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
+  { 172, 179, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
+  { 181, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_InvokeServiceRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetStateRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetStateRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkStateRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkStateResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_BulkStateItem_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetStateResponse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SaveStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_PublishEventRequest_default_instance_),
@@ -674,7 +774,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 20);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 23);
 }
 
 void AddDescriptorsImpl() {
@@ -685,77 +785,87 @@ void AddDescriptorsImpl() {
       ".proto\032!dapr/proto/common/v1/common.prot"
       "o\"X\n\024InvokeServiceRequest\022\n\n\002id\030\001 \001(\t\0224\n"
       "\007message\030\003 \001(\0132#.dapr.proto.common.v1.In"
-      "vokeRequest\"|\n\017GetStateRequest\022\022\n\nstore_"
-      "name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022H\n\013consistency\030\003"
-      " \001(\01623.dapr.proto.common.v1.StateOptions"
-      ".StateConsistency\"L\n\023GetBulkStateRequest"
-      "\022\022\n\nstore_name\030\001 \001(\t\022\014\n\004keys\030\002 \003(\t\022\023\n\013pa"
-      "rallelism\030\003 \001(\005\"K\n\024GetBulkStateResponse\022"
-      "3\n\005items\030\001 \003(\0132$.dapr.proto.runtime.v1.B"
-      "ulkStateItem\"8\n\rBulkStateItem\022\013\n\003key\030\001 \001"
-      "(\t\022\014\n\004data\030\002 \001(\014\022\014\n\004etag\030\003 \001(\t\".\n\020GetSta"
-      "teResponse\022\014\n\004data\030\001 \001(\014\022\014\n\004etag\030\002 \001(\t\"x"
-      "\n\022DeleteStateRequest\022\022\n\nstore_name\030\001 \001(\t"
-      "\022\013\n\003key\030\002 \001(\t\022\014\n\004etag\030\003 \001(\t\0223\n\007options\030\004"
-      " \001(\0132\".dapr.proto.common.v1.StateOptions"
-      "\"W\n\020SaveStateRequest\022\022\n\nstore_name\030\001 \001(\t"
-      "\022/\n\006states\030\002 \003(\0132\037.dapr.proto.common.v1."
-      "StateItem\"G\n\023PublishEventRequest\022\023\n\013pubs"
-      "ub_name\030\001 \001(\t\022\r\n\005topic\030\002 \001(\t\022\014\n\004data\030\003 \001"
-      "(\014\"\303\001\n\024InvokeBindingRequest\022\014\n\004name\030\001 \001("
-      "\t\022\014\n\004data\030\002 \001(\014\022K\n\010metadata\030\003 \003(\01329.dapr"
-      ".proto.runtime.v1.InvokeBindingRequest.M"
-      "etadataEntry\022\021\n\toperation\030\004 \001(\t\032/\n\rMetad"
-      "ataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001"
-      "\"\244\001\n\025InvokeBindingResponse\022\014\n\004data\030\001 \001(\014"
-      "\022L\n\010metadata\030\002 \003(\0132:.dapr.proto.runtime."
-      "v1.InvokeBindingResponse.MetadataEntry\032/"
-      "\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 "
-      "\001(\t:\0028\001\"\255\001\n\020GetSecretRequest\022\022\n\nstore_na"
-      "me\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022G\n\010metadata\030\003 \003(\0132"
-      "5.dapr.proto.runtime.v1.GetSecretRequest"
+      "vokeRequest\"\365\001\n\017GetStateRequest\022\022\n\nstore"
+      "_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022H\n\013consistency\030"
+      "\003 \001(\01623.dapr.proto.common.v1.StateOption"
+      "s.StateConsistency\022F\n\010metadata\030\004 \003(\01324.d"
+      "apr.proto.runtime.v1.GetStateRequest.Met"
+      "adataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t"
+      "\022\r\n\005value\030\002 \001(\t:\0028\001\"\311\001\n\023GetBulkStateRequ"
+      "est\022\022\n\nstore_name\030\001 \001(\t\022\014\n\004keys\030\002 \003(\t\022\023\n"
+      "\013parallelism\030\003 \001(\005\022J\n\010metadata\030\004 \003(\01328.d"
+      "apr.proto.runtime.v1.GetBulkStateRequest"
       ".MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001"
-      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001\n\021GetSecretRes"
-      "ponse\022@\n\004data\030\001 \003(\01322.dapr.proto.runtime"
-      ".v1.GetSecretResponse.DataEntry\032+\n\tDataE"
-      "ntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"f\n\033"
-      "TransactionalStateOperation\022\025\n\roperation"
-      "Type\030\001 \001(\t\0220\n\007request\030\002 \001(\0132\037.dapr.proto"
-      ".common.v1.StateItem\"\203\002\n\036ExecuteStateTra"
-      "nsactionRequest\022\021\n\tstoreName\030\001 \001(\t\022F\n\nop"
-      "erations\030\002 \003(\01322.dapr.proto.runtime.v1.T"
-      "ransactionalStateOperation\022U\n\010metadata\030\003"
-      " \003(\0132C.dapr.proto.runtime.v1.ExecuteStat"
-      "eTransactionRequest.MetadataEntry\032/\n\rMet"
-      "adataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
-      "8\0012\354\006\n\004Dapr\022d\n\rInvokeService\022+.dapr.prot"
-      "o.runtime.v1.InvokeServiceRequest\032$.dapr"
-      ".proto.common.v1.InvokeResponse\"\000\022]\n\010Get"
-      "State\022&.dapr.proto.runtime.v1.GetStateRe"
-      "quest\032\'.dapr.proto.runtime.v1.GetStateRe"
-      "sponse\"\000\022i\n\014GetBulkState\022*.dapr.proto.ru"
-      "ntime.v1.GetBulkStateRequest\032+.dapr.prot"
-      "o.runtime.v1.GetBulkStateResponse\"\000\022N\n\tS"
-      "aveState\022\'.dapr.proto.runtime.v1.SaveSta"
-      "teRequest\032\026.google.protobuf.Empty\"\000\022R\n\013D"
-      "eleteState\022).dapr.proto.runtime.v1.Delet"
-      "eStateRequest\032\026.google.protobuf.Empty\"\000\022"
-      "j\n\027ExecuteStateTransaction\0225.dapr.proto."
-      "runtime.v1.ExecuteStateTransactionReques"
-      "t\032\026.google.protobuf.Empty\"\000\022T\n\014PublishEv"
-      "ent\022*.dapr.proto.runtime.v1.PublishEvent"
-      "Request\032\026.google.protobuf.Empty\"\000\022l\n\rInv"
-      "okeBinding\022+.dapr.proto.runtime.v1.Invok"
-      "eBindingRequest\032,.dapr.proto.runtime.v1."
-      "InvokeBindingResponse\"\000\022`\n\tGetSecret\022\'.d"
-      "apr.proto.runtime.v1.GetSecretRequest\032(."
-      "dapr.proto.runtime.v1.GetSecretResponse\""
-      "\000Bi\n\nio.dapr.v1B\nDaprProtosZ1github.com/"
-      "dapr/dapr/pkg/proto/runtime/v1;runtime\252\002"
-      "\033Dapr.Client.Autogen.Grpc.v1b\006proto3"
+      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"K\n\024GetBulkStateR"
+      "esponse\0223\n\005items\030\001 \003(\0132$.dapr.proto.runt"
+      "ime.v1.BulkStateItem\"G\n\rBulkStateItem\022\013\n"
+      "\003key\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022\014\n\004etag\030\003 \001(\t\022\r"
+      "\n\005error\030\004 \001(\t\".\n\020GetStateResponse\022\014\n\004dat"
+      "a\030\001 \001(\014\022\014\n\004etag\030\002 \001(\t\"\364\001\n\022DeleteStateReq"
+      "uest\022\022\n\nstore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022\014\n"
+      "\004etag\030\003 \001(\t\0223\n\007options\030\004 \001(\0132\".dapr.prot"
+      "o.common.v1.StateOptions\022I\n\010metadata\030\005 \003"
+      "(\01327.dapr.proto.runtime.v1.DeleteStateRe"
+      "quest.MetadataEntry\032/\n\rMetadataEntry\022\013\n\003"
+      "key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"W\n\020SaveStat"
+      "eRequest\022\022\n\nstore_name\030\001 \001(\t\022/\n\006states\030\002"
+      " \003(\0132\037.dapr.proto.common.v1.StateItem\"G\n"
+      "\023PublishEventRequest\022\023\n\013pubsub_name\030\001 \001("
+      "\t\022\r\n\005topic\030\002 \001(\t\022\014\n\004data\030\003 \001(\014\"\303\001\n\024Invok"
+      "eBindingRequest\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030\002 "
+      "\001(\014\022K\n\010metadata\030\003 \003(\01329.dapr.proto.runti"
+      "me.v1.InvokeBindingRequest.MetadataEntry"
+      "\022\021\n\toperation\030\004 \001(\t\032/\n\rMetadataEntry\022\013\n\003"
+      "key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\244\001\n\025InvokeB"
+      "indingResponse\022\014\n\004data\030\001 \001(\014\022L\n\010metadata"
+      "\030\002 \003(\0132:.dapr.proto.runtime.v1.InvokeBin"
+      "dingResponse.MetadataEntry\032/\n\rMetadataEn"
+      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\255\001\n\020"
+      "GetSecretRequest\022\022\n\nstore_name\030\001 \001(\t\022\013\n\003"
+      "key\030\002 \001(\t\022G\n\010metadata\030\003 \003(\01325.dapr.proto"
+      ".runtime.v1.GetSecretRequest.MetadataEnt"
+      "ry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
+      "e\030\002 \001(\t:\0028\001\"\202\001\n\021GetSecretResponse\022@\n\004dat"
+      "a\030\001 \003(\01322.dapr.proto.runtime.v1.GetSecre"
+      "tResponse.DataEntry\032+\n\tDataEntry\022\013\n\003key\030"
+      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"f\n\033Transactiona"
+      "lStateOperation\022\025\n\roperationType\030\001 \001(\t\0220"
+      "\n\007request\030\002 \001(\0132\037.dapr.proto.common.v1.S"
+      "tateItem\"\203\002\n\036ExecuteStateTransactionRequ"
+      "est\022\021\n\tstoreName\030\001 \001(\t\022F\n\noperations\030\002 \003"
+      "(\01322.dapr.proto.runtime.v1.Transactional"
+      "StateOperation\022U\n\010metadata\030\003 \003(\0132C.dapr."
+      "proto.runtime.v1.ExecuteStateTransaction"
+      "Request.MetadataEntry\032/\n\rMetadataEntry\022\013"
+      "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\0012\354\006\n\004Dapr\022"
+      "d\n\rInvokeService\022+.dapr.proto.runtime.v1"
+      ".InvokeServiceRequest\032$.dapr.proto.commo"
+      "n.v1.InvokeResponse\"\000\022]\n\010GetState\022&.dapr"
+      ".proto.runtime.v1.GetStateRequest\032\'.dapr"
+      ".proto.runtime.v1.GetStateResponse\"\000\022i\n\014"
+      "GetBulkState\022*.dapr.proto.runtime.v1.Get"
+      "BulkStateRequest\032+.dapr.proto.runtime.v1"
+      ".GetBulkStateResponse\"\000\022N\n\tSaveState\022\'.d"
+      "apr.proto.runtime.v1.SaveStateRequest\032\026."
+      "google.protobuf.Empty\"\000\022R\n\013DeleteState\022)"
+      ".dapr.proto.runtime.v1.DeleteStateReques"
+      "t\032\026.google.protobuf.Empty\"\000\022j\n\027ExecuteSt"
+      "ateTransaction\0225.dapr.proto.runtime.v1.E"
+      "xecuteStateTransactionRequest\032\026.google.p"
+      "rotobuf.Empty\"\000\022T\n\014PublishEvent\022*.dapr.p"
+      "roto.runtime.v1.PublishEventRequest\032\026.go"
+      "ogle.protobuf.Empty\"\000\022l\n\rInvokeBinding\022+"
+      ".dapr.proto.runtime.v1.InvokeBindingRequ"
+      "est\032,.dapr.proto.runtime.v1.InvokeBindin"
+      "gResponse\"\000\022`\n\tGetSecret\022\'.dapr.proto.ru"
+      "ntime.v1.GetSecretRequest\032(.dapr.proto.r"
+      "untime.v1.GetSecretResponse\"\000Bi\n\nio.dapr"
+      ".v1B\nDaprProtosZ1github.com/dapr/dapr/pk"
+      "g/proto/runtime/v1;runtime\252\002\033Dapr.Client"
+      ".Autogen.Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 2916);
+      descriptor, 3304);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/dapr.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fempty_2eproto::AddDescriptors();
@@ -1078,12 +1188,30 @@ void InvokeServiceRequest::InternalSwap(InvokeServiceRequest* other) {
 
 // ===================================================================
 
+GetStateRequest_MetadataEntry_DoNotUse::GetStateRequest_MetadataEntry_DoNotUse() {}
+GetStateRequest_MetadataEntry_DoNotUse::GetStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GetStateRequest_MetadataEntry_DoNotUse::MergeFrom(const GetStateRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GetStateRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[1];
+}
+void GetStateRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
 void GetStateRequest::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int GetStateRequest::kStoreNameFieldNumber;
 const int GetStateRequest::kKeyFieldNumber;
 const int GetStateRequest::kConsistencyFieldNumber;
+const int GetStateRequest::kMetadataFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 GetStateRequest::GetStateRequest()
@@ -1097,6 +1225,7 @@ GetStateRequest::GetStateRequest(const GetStateRequest& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
   store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.store_name().size() > 0) {
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -1145,6 +1274,7 @@ void GetStateRequest::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  metadata_.Clear();
   store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   consistency_ = 0;
@@ -1208,6 +1338,33 @@ bool GetStateRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // map<string, string> metadata = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          GetStateRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GetStateRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -1260,6 +1417,59 @@ void GetStateRequest::SerializeWithCachedSizes(
       3, this->consistency(), output);
   }
 
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -1302,6 +1512,63 @@ void GetStateRequest::SerializeWithCachedSizes(
       3, this->consistency(), target);
   }
 
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -1319,6 +1586,20 @@ size_t GetStateRequest::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // map<string, string> metadata = 4;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<GetStateRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
   // string store_name = 1;
   if (this->store_name().size() > 0) {
     total_size += 1 +
@@ -1366,6 +1647,7 @@ void GetStateRequest::MergeFrom(const GetStateRequest& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  metadata_.MergeFrom(from.metadata_);
   if (from.store_name().size() > 0) {
 
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -1403,6 +1685,7 @@ void GetStateRequest::Swap(GetStateRequest* other) {
 }
 void GetStateRequest::InternalSwap(GetStateRequest* other) {
   using std::swap;
+  metadata_.Swap(&other->metadata_);
   store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1419,12 +1702,30 @@ void GetStateRequest::InternalSwap(GetStateRequest* other) {
 
 // ===================================================================
 
+GetBulkStateRequest_MetadataEntry_DoNotUse::GetBulkStateRequest_MetadataEntry_DoNotUse() {}
+GetBulkStateRequest_MetadataEntry_DoNotUse::GetBulkStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GetBulkStateRequest_MetadataEntry_DoNotUse::MergeFrom(const GetBulkStateRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GetBulkStateRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[3];
+}
+void GetBulkStateRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
 void GetBulkStateRequest::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int GetBulkStateRequest::kStoreNameFieldNumber;
 const int GetBulkStateRequest::kKeysFieldNumber;
 const int GetBulkStateRequest::kParallelismFieldNumber;
+const int GetBulkStateRequest::kMetadataFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 GetBulkStateRequest::GetBulkStateRequest()
@@ -1439,6 +1740,7 @@ GetBulkStateRequest::GetBulkStateRequest(const GetBulkStateRequest& from)
       _internal_metadata_(NULL),
       keys_(from.keys_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
   store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.store_name().size() > 0) {
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -1482,6 +1784,7 @@ void GetBulkStateRequest::Clear() {
   (void) cached_has_bits;
 
   keys_.Clear();
+  metadata_.Clear();
   store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   parallelism_ = 0;
   _internal_metadata_.Clear();
@@ -1544,6 +1847,33 @@ bool GetBulkStateRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // map<string, string> metadata = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          GetBulkStateRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GetBulkStateRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -1595,6 +1925,59 @@ void GetBulkStateRequest::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->parallelism(), output);
   }
 
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetBulkStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetBulkStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -1635,6 +2018,63 @@ void GetBulkStateRequest::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->parallelism(), target);
   }
 
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetBulkStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetBulkStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetBulkStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -1658,6 +2098,20 @@ size_t GetBulkStateRequest::ByteSizeLong() const {
   for (int i = 0, n = this->keys_size(); i < n; i++) {
     total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
       this->keys(i));
+  }
+
+  // map<string, string> metadata = 4;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<GetBulkStateRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
   }
 
   // string store_name = 1;
@@ -1702,6 +2156,7 @@ void GetBulkStateRequest::MergeFrom(const GetBulkStateRequest& from) {
   (void) cached_has_bits;
 
   keys_.MergeFrom(from.keys_);
+  metadata_.MergeFrom(from.metadata_);
   if (from.store_name().size() > 0) {
 
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -1736,6 +2191,7 @@ void GetBulkStateRequest::Swap(GetBulkStateRequest* other) {
 void GetBulkStateRequest::InternalSwap(GetBulkStateRequest* other) {
   using std::swap;
   keys_.InternalSwap(CastToBase(&other->keys_));
+  metadata_.Swap(&other->metadata_);
   store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   swap(parallelism_, other->parallelism_);
@@ -1985,6 +2441,7 @@ void BulkStateItem::InitAsDefaultInstance() {
 const int BulkStateItem::kKeyFieldNumber;
 const int BulkStateItem::kDataFieldNumber;
 const int BulkStateItem::kEtagFieldNumber;
+const int BulkStateItem::kErrorFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 BulkStateItem::BulkStateItem()
@@ -2010,6 +2467,10 @@ BulkStateItem::BulkStateItem(const BulkStateItem& from)
   if (from.etag().size() > 0) {
     etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
   }
+  error_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.error().size() > 0) {
+    error_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.error_);
+  }
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.BulkStateItem)
 }
 
@@ -2017,6 +2478,7 @@ void BulkStateItem::SharedCtor() {
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 BulkStateItem::~BulkStateItem() {
@@ -2028,6 +2490,7 @@ void BulkStateItem::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   etag_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void BulkStateItem::SetCachedSize(int size) const {
@@ -2053,6 +2516,7 @@ void BulkStateItem::Clear() {
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -2104,6 +2568,22 @@ bool BulkStateItem::MergePartialFromCodedStream(
             this->etag().data(), static_cast<int>(this->etag().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
             "dapr.proto.runtime.v1.BulkStateItem.etag"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string error = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_error()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->error().data(), static_cast<int>(this->error().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.BulkStateItem.error"));
         } else {
           goto handle_unusual;
         }
@@ -2162,6 +2642,16 @@ void BulkStateItem::SerializeWithCachedSizes(
       3, this->etag(), output);
   }
 
+  // string error = 4;
+  if (this->error().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->error().data(), static_cast<int>(this->error().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.BulkStateItem.error");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      4, this->error(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -2205,6 +2695,17 @@ void BulkStateItem::SerializeWithCachedSizes(
         3, this->etag(), target);
   }
 
+  // string error = 4;
+  if (this->error().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->error().data(), static_cast<int>(this->error().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.BulkStateItem.error");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        4, this->error(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -2241,6 +2742,13 @@ size_t BulkStateItem::ByteSizeLong() const {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::StringSize(
         this->etag());
+  }
+
+  // string error = 4;
+  if (this->error().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->error());
   }
 
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
@@ -2282,6 +2790,10 @@ void BulkStateItem::MergeFrom(const BulkStateItem& from) {
 
     etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
   }
+  if (from.error().size() > 0) {
+
+    error_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.error_);
+  }
 }
 
 void BulkStateItem::CopyFrom(const ::google::protobuf::Message& from) {
@@ -2313,6 +2825,8 @@ void BulkStateItem::InternalSwap(BulkStateItem* other) {
   data_.Swap(&other->data_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   etag_.Swap(&other->etag_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  error_.Swap(&other->error_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
@@ -2613,6 +3127,23 @@ void GetStateResponse::InternalSwap(GetStateResponse* other) {
 
 // ===================================================================
 
+DeleteStateRequest_MetadataEntry_DoNotUse::DeleteStateRequest_MetadataEntry_DoNotUse() {}
+DeleteStateRequest_MetadataEntry_DoNotUse::DeleteStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void DeleteStateRequest_MetadataEntry_DoNotUse::MergeFrom(const DeleteStateRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata DeleteStateRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[8];
+}
+void DeleteStateRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
 void DeleteStateRequest::InitAsDefaultInstance() {
   ::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_._instance.get_mutable()->options_ = const_cast< ::dapr::proto::common::v1::StateOptions*>(
       ::dapr::proto::common::v1::StateOptions::internal_default_instance());
@@ -2628,6 +3159,7 @@ const int DeleteStateRequest::kStoreNameFieldNumber;
 const int DeleteStateRequest::kKeyFieldNumber;
 const int DeleteStateRequest::kEtagFieldNumber;
 const int DeleteStateRequest::kOptionsFieldNumber;
+const int DeleteStateRequest::kMetadataFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 DeleteStateRequest::DeleteStateRequest()
@@ -2641,6 +3173,7 @@ DeleteStateRequest::DeleteStateRequest(const DeleteStateRequest& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
   store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.store_name().size() > 0) {
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -2700,6 +3233,7 @@ void DeleteStateRequest::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  metadata_.Clear();
   store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2780,6 +3314,33 @@ bool DeleteStateRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // map<string, string> metadata = 5;
+      case 5: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
+          DeleteStateRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              DeleteStateRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -2842,6 +3403,59 @@ void DeleteStateRequest::SerializeWithCachedSizes(
       4, this->_internal_options(), output);
   }
 
+  // map<string, string> metadata = 5;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<DeleteStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            5, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<DeleteStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            5, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -2896,6 +3510,63 @@ void DeleteStateRequest::SerializeWithCachedSizes(
         4, this->_internal_options(), deterministic, target);
   }
 
+  // map<string, string> metadata = 5;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.DeleteStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<DeleteStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       5, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<DeleteStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       5, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -2913,6 +3584,20 @@ size_t DeleteStateRequest::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // map<string, string> metadata = 5;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<DeleteStateRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
   // string store_name = 1;
   if (this->store_name().size() > 0) {
     total_size += 1 +
@@ -2968,6 +3653,7 @@ void DeleteStateRequest::MergeFrom(const DeleteStateRequest& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  metadata_.MergeFrom(from.metadata_);
   if (from.store_name().size() > 0) {
 
     store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
@@ -3009,6 +3695,7 @@ void DeleteStateRequest::Swap(DeleteStateRequest* other) {
 }
 void DeleteStateRequest::InternalSwap(DeleteStateRequest* other) {
   using std::swap;
+  metadata_.Swap(&other->metadata_);
   store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -3670,7 +4357,7 @@ void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(const InvokeBindingR
 }
 ::google::protobuf::Metadata InvokeBindingRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[9];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[12];
 }
 void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -4189,7 +4876,7 @@ void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(const InvokeBinding
 }
 ::google::protobuf::Metadata InvokeBindingResponse_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[11];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[14];
 }
 void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -4592,7 +5279,7 @@ void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(const GetSecretRequest_M
 }
 ::google::protobuf::Metadata GetSecretRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[13];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[16];
 }
 void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -5065,7 +5752,7 @@ void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetSecretResponse_Dat
 }
 ::google::protobuf::Metadata GetSecretResponse_DataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[15];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[18];
 }
 void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -5720,7 +6407,7 @@ void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(const Exec
 }
 ::google::protobuf::Metadata ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[18];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[21];
 }
 void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6181,8 +6868,14 @@ namespace protobuf {
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::InvokeServiceRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::InvokeServiceRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::InvokeServiceRequest >(arena);
 }
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse >(arena);
+}
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetStateRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetBulkStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetBulkStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetBulkStateRequest >(arena);
@@ -6195,6 +6888,9 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::BulkSt
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetStateResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetStateResponse >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetStateResponse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::DeleteStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::DeleteStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::DeleteStateRequest >(arena);

--- a/src/dapr/proto/runtime/v1/dapr.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.pb.h
@@ -43,7 +43,7 @@ namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[20];
+  static const ::google::protobuf::internal::ParseTable schema[23];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -60,6 +60,9 @@ extern BulkStateItemDefaultTypeInternal _BulkStateItem_default_instance_;
 class DeleteStateRequest;
 class DeleteStateRequestDefaultTypeInternal;
 extern DeleteStateRequestDefaultTypeInternal _DeleteStateRequest_default_instance_;
+class DeleteStateRequest_MetadataEntry_DoNotUse;
+class DeleteStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern DeleteStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class ExecuteStateTransactionRequest;
 class ExecuteStateTransactionRequestDefaultTypeInternal;
 extern ExecuteStateTransactionRequestDefaultTypeInternal _ExecuteStateTransactionRequest_default_instance_;
@@ -69,6 +72,9 @@ extern ExecuteStateTransactionRequest_MetadataEntry_DoNotUseDefaultTypeInternal 
 class GetBulkStateRequest;
 class GetBulkStateRequestDefaultTypeInternal;
 extern GetBulkStateRequestDefaultTypeInternal _GetBulkStateRequest_default_instance_;
+class GetBulkStateRequest_MetadataEntry_DoNotUse;
+class GetBulkStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern GetBulkStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _GetBulkStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class GetBulkStateResponse;
 class GetBulkStateResponseDefaultTypeInternal;
 extern GetBulkStateResponseDefaultTypeInternal _GetBulkStateResponse_default_instance_;
@@ -87,6 +93,9 @@ extern GetSecretResponse_DataEntry_DoNotUseDefaultTypeInternal _GetSecretRespons
 class GetStateRequest;
 class GetStateRequestDefaultTypeInternal;
 extern GetStateRequestDefaultTypeInternal _GetStateRequest_default_instance_;
+class GetStateRequest_MetadataEntry_DoNotUse;
+class GetStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern GetStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _GetStateRequest_MetadataEntry_DoNotUse_default_instance_;
 class GetStateResponse;
 class GetStateResponseDefaultTypeInternal;
 extern GetStateResponseDefaultTypeInternal _GetStateResponse_default_instance_;
@@ -122,15 +131,18 @@ namespace google {
 namespace protobuf {
 template<> ::dapr::proto::runtime::v1::BulkStateItem* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::BulkStateItem>(Arena*);
 template<> ::dapr::proto::runtime::v1::DeleteStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::DeleteStateRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::ExecuteStateTransactionRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetStateRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetStateResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetStateResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::InvokeBindingRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::InvokeBindingRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse>(Arena*);
@@ -273,6 +285,27 @@ class InvokeServiceRequest : public ::google::protobuf::Message /* @@protoc_inse
 };
 // -------------------------------------------------------------------
 
+class GetStateRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GetStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GetStateRequest_MetadataEntry_DoNotUse();
+  GetStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GetStateRequest_MetadataEntry_DoNotUse& other);
+  static const GetStateRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GetStateRequest_MetadataEntry_DoNotUse*>(&_GetStateRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
 class GetStateRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.GetStateRequest) */ {
  public:
   GetStateRequest();
@@ -308,7 +341,7 @@ class GetStateRequest : public ::google::protobuf::Message /* @@protoc_insertion
                &_GetStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    2;
 
   void Swap(GetStateRequest* other);
   friend void swap(GetStateRequest& a, GetStateRequest& b) {
@@ -358,7 +391,17 @@ class GetStateRequest : public ::google::protobuf::Message /* @@protoc_insertion
 
   // nested types ----------------------------------------------------
 
+
   // accessors -------------------------------------------------------
+
+  // map<string, string> metadata = 4;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 4;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
 
   // string store_name = 1;
   void clear_store_name();
@@ -398,12 +441,39 @@ class GetStateRequest : public ::google::protobuf::Message /* @@protoc_insertion
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      GetStateRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr store_name_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   int consistency_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
+// -------------------------------------------------------------------
+
+class GetBulkStateRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetBulkStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GetBulkStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GetBulkStateRequest_MetadataEntry_DoNotUse();
+  GetBulkStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GetBulkStateRequest_MetadataEntry_DoNotUse& other);
+  static const GetBulkStateRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GetBulkStateRequest_MetadataEntry_DoNotUse*>(&_GetBulkStateRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
 // -------------------------------------------------------------------
 
 class GetBulkStateRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.GetBulkStateRequest) */ {
@@ -441,7 +511,7 @@ class GetBulkStateRequest : public ::google::protobuf::Message /* @@protoc_inser
                &_GetBulkStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   void Swap(GetBulkStateRequest* other);
   friend void swap(GetBulkStateRequest& a, GetBulkStateRequest& b) {
@@ -491,6 +561,7 @@ class GetBulkStateRequest : public ::google::protobuf::Message /* @@protoc_inser
 
   // nested types ----------------------------------------------------
 
+
   // accessors -------------------------------------------------------
 
   // repeated string keys = 2;
@@ -514,6 +585,15 @@ class GetBulkStateRequest : public ::google::protobuf::Message /* @@protoc_inser
   void add_keys(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& keys() const;
   ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_keys();
+
+  // map<string, string> metadata = 4;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 4;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
 
   // string store_name = 1;
   void clear_store_name();
@@ -540,6 +620,12 @@ class GetBulkStateRequest : public ::google::protobuf::Message /* @@protoc_inser
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::RepeatedPtrField< ::std::string> keys_;
+  ::google::protobuf::internal::MapField<
+      GetBulkStateRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr store_name_;
   ::google::protobuf::int32 parallelism_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
@@ -582,7 +668,7 @@ class GetBulkStateResponse : public ::google::protobuf::Message /* @@protoc_inse
                &_GetBulkStateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   void Swap(GetBulkStateResponse* other);
   friend void swap(GetBulkStateResponse& a, GetBulkStateResponse& b) {
@@ -691,7 +777,7 @@ class BulkStateItem : public ::google::protobuf::Message /* @@protoc_insertion_p
                &_BulkStateItem_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   void Swap(BulkStateItem* other);
   friend void swap(BulkStateItem& a, BulkStateItem& b) {
@@ -785,6 +871,20 @@ class BulkStateItem : public ::google::protobuf::Message /* @@protoc_insertion_p
   ::std::string* release_etag();
   void set_allocated_etag(::std::string* etag);
 
+  // string error = 4;
+  void clear_error();
+  static const int kErrorFieldNumber = 4;
+  const ::std::string& error() const;
+  void set_error(const ::std::string& value);
+  #if LANG_CXX11
+  void set_error(::std::string&& value);
+  #endif
+  void set_error(const char* value);
+  void set_error(const char* value, size_t size);
+  ::std::string* mutable_error();
+  ::std::string* release_error();
+  void set_allocated_error(::std::string* error);
+
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.BulkStateItem)
  private:
 
@@ -792,6 +892,7 @@ class BulkStateItem : public ::google::protobuf::Message /* @@protoc_insertion_p
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr data_;
   ::google::protobuf::internal::ArenaStringPtr etag_;
+  ::google::protobuf::internal::ArenaStringPtr error_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -832,7 +933,7 @@ class GetStateResponse : public ::google::protobuf::Message /* @@protoc_insertio
                &_GetStateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   void Swap(GetStateResponse* other);
   friend void swap(GetStateResponse& a, GetStateResponse& b) {
@@ -923,6 +1024,27 @@ class GetStateResponse : public ::google::protobuf::Message /* @@protoc_insertio
 };
 // -------------------------------------------------------------------
 
+class DeleteStateRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<DeleteStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<DeleteStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  DeleteStateRequest_MetadataEntry_DoNotUse();
+  DeleteStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const DeleteStateRequest_MetadataEntry_DoNotUse& other);
+  static const DeleteStateRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const DeleteStateRequest_MetadataEntry_DoNotUse*>(&_DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
 class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.DeleteStateRequest) */ {
  public:
   DeleteStateRequest();
@@ -958,7 +1080,7 @@ class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insert
                &_DeleteStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    9;
 
   void Swap(DeleteStateRequest* other);
   friend void swap(DeleteStateRequest& a, DeleteStateRequest& b) {
@@ -1008,7 +1130,17 @@ class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insert
 
   // nested types ----------------------------------------------------
 
+
   // accessors -------------------------------------------------------
+
+  // map<string, string> metadata = 5;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 5;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
 
   // string store_name = 1;
   void clear_store_name();
@@ -1068,6 +1200,12 @@ class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insert
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      DeleteStateRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr store_name_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr etag_;
@@ -1112,7 +1250,7 @@ class SaveStateRequest : public ::google::protobuf::Message /* @@protoc_insertio
                &_SaveStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    10;
 
   void Swap(SaveStateRequest* other);
   friend void swap(SaveStateRequest& a, SaveStateRequest& b) {
@@ -1236,7 +1374,7 @@ class PublishEventRequest : public ::google::protobuf::Message /* @@protoc_inser
                &_PublishEventRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    11;
 
   void Swap(PublishEventRequest* other);
   friend void swap(PublishEventRequest& a, PublishEventRequest& b) {
@@ -1398,7 +1536,7 @@ class InvokeBindingRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_InvokeBindingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    13;
 
   void Swap(InvokeBindingRequest* other);
   friend void swap(InvokeBindingRequest& a, InvokeBindingRequest& b) {
@@ -1576,7 +1714,7 @@ class InvokeBindingResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_InvokeBindingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    15;
 
   void Swap(InvokeBindingResponse* other);
   friend void swap(InvokeBindingResponse& a, InvokeBindingResponse& b) {
@@ -1724,7 +1862,7 @@ class GetSecretRequest : public ::google::protobuf::Message /* @@protoc_insertio
                &_GetSecretRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    17;
 
   void Swap(GetSecretRequest* other);
   friend void swap(GetSecretRequest& a, GetSecretRequest& b) {
@@ -1887,7 +2025,7 @@ class GetSecretResponse : public ::google::protobuf::Message /* @@protoc_inserti
                &_GetSecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    19;
 
   void Swap(GetSecretResponse* other);
   friend void swap(GetSecretResponse& a, GetSecretResponse& b) {
@@ -1999,7 +2137,7 @@ class TransactionalStateOperation : public ::google::protobuf::Message /* @@prot
                &_TransactionalStateOperation_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    20;
 
   void Swap(TransactionalStateOperation* other);
   friend void swap(TransactionalStateOperation& a, TransactionalStateOperation& b) {
@@ -2144,7 +2282,7 @@ class ExecuteStateTransactionRequest : public ::google::protobuf::Message /* @@p
                &_ExecuteStateTransactionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    22;
 
   void Swap(ExecuteStateTransactionRequest* other);
   friend void swap(ExecuteStateTransactionRequest& a, ExecuteStateTransactionRequest& b) {
@@ -2361,6 +2499,8 @@ inline void InvokeServiceRequest::set_allocated_message(::dapr::proto::common::v
 
 // -------------------------------------------------------------------
 
+// -------------------------------------------------------------------
+
 // GetStateRequest
 
 // string store_name = 1;
@@ -2482,6 +2622,26 @@ inline void GetStateRequest::set_consistency(::dapr::proto::common::v1::StateOpt
   consistency_ = value;
   // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetStateRequest.consistency)
 }
+
+// map<string, string> metadata = 4;
+inline int GetStateRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void GetStateRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GetStateRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.GetStateRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GetStateRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.GetStateRequest.metadata)
+  return metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
 
@@ -2621,6 +2781,24 @@ inline void GetBulkStateRequest::set_parallelism(::google::protobuf::int32 value
   
   parallelism_ = value;
   // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetBulkStateRequest.parallelism)
+}
+
+// map<string, string> metadata = 4;
+inline int GetBulkStateRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void GetBulkStateRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GetBulkStateRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.GetBulkStateRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GetBulkStateRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.GetBulkStateRequest.metadata)
+  return metadata_.MutableMap();
 }
 
 // -------------------------------------------------------------------
@@ -2820,6 +2998,59 @@ inline void BulkStateItem::set_allocated_etag(::std::string* etag) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.BulkStateItem.etag)
 }
 
+// string error = 4;
+inline void BulkStateItem::clear_error() {
+  error_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& BulkStateItem::error() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.BulkStateItem.error)
+  return error_.GetNoArena();
+}
+inline void BulkStateItem::set_error(const ::std::string& value) {
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.BulkStateItem.error)
+}
+#if LANG_CXX11
+inline void BulkStateItem::set_error(::std::string&& value) {
+  
+  error_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.BulkStateItem.error)
+}
+#endif
+inline void BulkStateItem::set_error(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.BulkStateItem.error)
+}
+inline void BulkStateItem::set_error(const char* value, size_t size) {
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.BulkStateItem.error)
+}
+inline ::std::string* BulkStateItem::mutable_error() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.BulkStateItem.error)
+  return error_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* BulkStateItem::release_error() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.BulkStateItem.error)
+  
+  return error_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void BulkStateItem::set_allocated_error(::std::string* error) {
+  if (error != NULL) {
+    
+  } else {
+    
+  }
+  error_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), error);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.BulkStateItem.error)
+}
+
 // -------------------------------------------------------------------
 
 // GetStateResponse
@@ -2929,6 +3160,8 @@ inline void GetStateResponse::set_allocated_etag(::std::string* etag) {
   etag_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), etag);
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.GetStateResponse.etag)
 }
+
+// -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
 
@@ -3139,6 +3372,24 @@ inline void DeleteStateRequest::set_allocated_options(::dapr::proto::common::v1:
   }
   options_ = options;
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.DeleteStateRequest.options)
+}
+
+// map<string, string> metadata = 5;
+inline int DeleteStateRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void DeleteStateRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+DeleteStateRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.DeleteStateRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+DeleteStateRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.DeleteStateRequest.metadata)
+  return metadata_.MutableMap();
 }
 
 // -------------------------------------------------------------------
@@ -4017,6 +4268,12 @@ ExecuteStateTransactionRequest::mutable_metadata() {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Pulled latest .proto files and built examples.

closes: #17 

Example test results.
```

ℹ️  Updating metadata for app command: ./echo_app caller 6100 callee
✅  You're up and running! Both Dapr and your app logs will appear here.

== APP == Connecting to 127.0.0.1:40131...

== APP == Call echo method to callee

== APP == OnInvoke() is called

== APP == Got the message: hello dapr

== APP == Received [ack : hello dapr] from callee

== APP == OnInvoke() is called

== APP == Got the message: hello dapr

== APP == Received [ack : hello dapr] from callee

== APP == OnInvoke() is called

== APP == Got the message: hello dapr

== APP == Received [ack : hello dapr] from callee
```