### PR TITLE
Automate pulling .proto files from dapr runtime (#19)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,30 +8,43 @@ PROTOC = protoc
 GRPC_CPP_PLUGIN = grpc_cpp_plugin
 GRPC_CPP_PLUGIN_PATH ?= `which $(GRPC_CPP_PLUGIN)`
 
+OBJ_FILES = src/dapr/proto/common/v1/common.pb.o src/dapr/proto/runtime/v1/dapr.pb.o src/dapr/proto/runtime/v1/dapr.grpc.pb.o src/dapr/proto/runtime/v1/appcallback.pb.o src/dapr/proto/runtime/v1/appcallback.grpc.pb.o
+
+PROTO_FILES = dapr/proto/runtime/v1/dapr.proto dapr/proto/runtime/v1/appcallback.proto dapr/proto/common/v1/common.proto
+
 PROTOS_PATH = .
+
+DAPR_TARGET ?= master
 
 vpath %.proto $(PROTOS_PATH)
 
 all: system-check libdapr.so
 
-libdapr.so : ./src/dapr/proto/common/v1/common.pb.o ./src/dapr/proto/runtime/v1/dapr.pb.o ./src/dapr/proto/runtime/v1/dapr.grpc.pb.o ./src/dapr/proto/runtime/v1/appcallback.pb.o ./src/dapr/proto/runtime/v1/appcallback.grpc.pb.o
+libdapr.so : $(OBJ_FILES)
 	-mkdir -p ./out
 	$(CXX) -shared -Wl,-soname,libdapr.so.0 -o ./out/libdapr.0.2.0.so ./src/dapr/proto/runtime/v1/*.o ./src/dapr/proto/common/v1/*.o
 
-%.o : %.cc
+%.o: %.cc
 	$(CXX) -c -fPIC -I./src $< -o $@
 
-.PRECIOUS: %.grpc.pb.cc
-%.grpc.pb.cc: %.proto
+.PRECIOUS: src/%.grpc.pb.cc
+src/%.grpc.pb.cc: %.proto
 	$(PROTOC) -I $(PROTOS_PATH) --grpc_out=./src/ --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) $<
 
-.PRECIOUS: %.pb.cc
-%.pb.cc: %.proto
+.PRECIOUS: src/%.pb.cc
+src/%.pb.cc: %.proto
+	mkdir -p ./src
 	$(PROTOC) -I $(PROTOS_PATH) --cpp_out=./src/ $<
 
 clean:
 	rm -f ./src/dapr/proto/common/v1/*.o ./src/dapr/proto/runtime/v1/*.o
 	rm -rf ./out
+
+refresh_proto_files:
+	for file in $(PROTO_FILES); do \
+		curl -o $$file https://raw.githubusercontent.com/dapr/dapr/$(DAPR_TARGET)/$$file; \
+	done
+
 
 # The following is to test your system and ensure a smoother experience.
 # They are by no means necessary to actually compile a grpc-enabled software.

--- a/README.md
+++ b/README.md
@@ -10,18 +10,15 @@ Alpha quality.
 2. Install [VSCode](https://code.visualstudio.com/download)
 3. Install [VSCode Remote - Container extension](https://code.visualstudio.com/docs/remote/containers)
 
-### Generate gRPC client
+### To refresh .proto files from upstream dapr
 
-1. Copy dapr.proto from https://github.com/dapr/dapr/tree/master/pkg/proto/dapr to [proto](./proto)
-2. Copy daprclient.proto from https://github.com/dapr/dapr/tree/master/pkg/proto/daprclient to [proto](./proto)
-3. Generate client
+1. Rebuild and commit generated API
     ```bash
-    make ./dapr/proto/common/v1/common.pb.cc
-    make ./dapr/proto/runtime/v1/dapr.grpc.pb.cc
-    make ./dapr/proto/runtime/v1/dapr.pb.cc
-    make ./dapr/proto/runtime/v1/appcallback.grpc.pb.cc
-    make ./dapr/proto/runtime/v1/appcallback.pb.cc
+    export DAPR_TARGET=<runtime_release_tag>
+    make refresh_proto_files && make && git add src/dapr/proto/*/v1/*{.cc,.h} dapr/proto/*/v1/*.proto 
+    git commit -m "Updating to dapr runtime $DAPR_TARGET"
     ```
+2. Submit a PR with the changes
 
 ### Build library
 


### PR DESCRIPTION
We now have a makefile target for pulling protofiles, and make will now automatically the necessary .cc files as part of the default target.

closes: #19 

