### PR TITLE
Update for 1.0.0-rc.3

### DIFF
--- a/dapr/proto/common/v1/common.proto
+++ b/dapr/proto/common/v1/common.proto
@@ -89,13 +89,19 @@ message StateItem {
 
   // The entity tag which represents the specific version of data.
   // The exact ETag format is defined by the corresponding data store.
-  string etag = 3;
+  Etag etag = 3;
 
   // The metadata which will be passed to state store component.
   map<string,string> metadata = 4;
 
   // Options for concurrency and consistency to save the state.
   StateOptions options = 5;
+}
+
+// Etag represents a state item version
+message Etag {
+  // value sets the etag value
+  string value = 1;
 }
 
 // StateOptions configures concurrency and consistency for state operations

--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -32,7 +32,10 @@ service Dapr {
 
   // Deletes the state for a specific key.
   rpc DeleteState(DeleteStateRequest) returns (google.protobuf.Empty) {}
-  
+
+  // Deletes a bulk of state items for a list of keys
+  rpc DeleteBulkState(DeleteBulkStateRequest) returns (google.protobuf.Empty) {}
+
   // Executes transactions for a specified store
   rpc ExecuteStateTransaction(ExecuteStateTransactionRequest) returns (google.protobuf.Empty) {}
 
@@ -68,6 +71,12 @@ service Dapr {
 
   // InvokeActor calls a method on an actor.
   rpc InvokeActor (InvokeActorRequest) returns (InvokeActorResponse) {}
+
+  // Gets metadata of the sidecar
+  rpc GetMetadata (google.protobuf.Empty) returns (GetMetadataResponse) {}
+
+  // Sets value in extended metadata of the sidecar
+  rpc SetMetadata (SetMetadataRequest) returns (google.protobuf.Empty) {}
 }
 
 // InvokeServiceRequest represents the request message for Service invocation.
@@ -158,7 +167,7 @@ message DeleteStateRequest {
 
   // The entity tag which represents the specific version of data.
   // The exact ETag format is defined by the corresponding data store.
-  string etag = 3;
+  common.v1.Etag etag = 3;
 
   // State operation options which includes concurrency/
   // consistency/retry_policy.
@@ -166,6 +175,15 @@ message DeleteStateRequest {
 
   // The metadata which will be sent to state store components.
   map<string,string> metadata = 5;
+}
+
+// DeleteBulkStateRequest is the message to delete a list of key-value states from specific state store.
+message DeleteBulkStateRequest {
+  // The name of state store.
+  string store_name = 1;
+
+  // The array of the state key values.
+  repeated common.v1.StateItem states = 2;
 }
 
 // SaveStateRequest is the message to save multiple states into state store.
@@ -256,11 +274,16 @@ message GetBulkSecretRequest {
   map<string,string> metadata = 2;
 }
 
-// GetBulkSecretResponse is the response message to convey the requested secret.
+// SecretResponse is a map of decrypted string/string values
+message SecretResponse {
+  map<string, string> secrets = 1;
+}
+
+// GetBulkSecretResponse is the response message to convey the requested secrets.
 message GetBulkSecretResponse {
   // data hold the secret values. Some secret store, such as kubernetes secret
   // store, can save multiple secrets for single secret key.
-  map<string, string> data = 1;
+  map<string, SecretResponse> data = 1;
 }
 
 // TransactionalStateOperation is the message to execute a specified operation with a key-value pair.
@@ -356,4 +379,28 @@ message InvokeActorRequest {
 // InvokeActorResponse is the method that returns an actor invocation response.
 message InvokeActorResponse {
   bytes data = 1;
+}
+
+// GetMetadataResponse is a message that is returned on GetMetadata rpc call
+message GetMetadataResponse {
+  string id = 1;
+  repeated ActiveActorsCount active_actors_count = 2;
+  repeated RegisteredComponents registered_components = 3;
+  map<string,string> extended_metadata = 4;
+}
+
+message ActiveActorsCount {
+  string type = 1;
+  int32 count = 2;
+}
+
+message RegisteredComponents {
+  string name = 1;
+  string type = 2;
+  string version = 3;
+}
+
+message SetMetadataRequest {
+  string key = 1;
+  string value = 2;
 }

--- a/examples/echo_app/README.md
+++ b/examples/echo_app/README.md
@@ -10,22 +10,58 @@ This echo app example shows how to use service invocation using gRPC API. You ca
 1. Make sure that you reopen in container on VSCode
 2. Open new bash terminal
 3. Build echo_app
+
 ```
 cd examples/echo_app
+```
+
+<!-- STEP
+name: Build example
+-->
+
+```bash
 make
 ```
+
+<!-- END_STEP -->
 
 ### Run callee app
 
 1. Open new bash terminal
 2. Run callee app
-```
+
+<!-- STEP
+name: Run callee
+expected_stdout_lines:
+  - '== APP == OnInvoke() is called'
+  - '== APP == Got the message: hello dapr'
+background: true
+sleep: 5 
+-->
+
+```bash
 dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000
 ```
+
+<!-- END_STEP -->
+
 3. Run caller app
-```
+
+<!-- STEP
+name: Run caller
+expected_stdout_lines:
+  - "== APP == Call echo method to callee"
+  - "== APP == Received [ack : hello dapr] from callee"
+background: true
+sleep: 5 
+-->
+
+```bash
 dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee
 ```
+
+<!-- END_STEP -->
+
 4. Check the logs
 From callee app:
 ```
@@ -44,6 +80,23 @@ From caller app:
 == APP == Received [ack : hello dapr] from callee
 ...
 ```
+
+## Cleanup
+
+<!-- STEP
+expected_stdout_lines: 
+  - '✅  app stopped successfully: echo_app'
+  - '✅  app stopped successfully: callee'
+expected_stderr_lines:
+name: Shutdown dapr
+-->
+
+```bash
+dapr stop --app-id echo_app
+dapr stop --app-id callee
+```
+
+<!-- END_STEP -->
 
 ## gRPC Debug
 

--- a/src/dapr/proto/common/v1/common.pb.cc
+++ b/src/dapr/proto/common/v1/common.pb.cc
@@ -20,6 +20,7 @@
 // @@protoc_insertion_point(includes)
 
 namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_Etag;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_HTTPExtension_QuerystringEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_StateItem_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_StateOptions;
@@ -62,6 +63,11 @@ class StateItemDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<StateItem>
       _instance;
 } _StateItem_default_instance_;
+class EtagDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<Etag>
+      _instance;
+} _Etag_default_instance_;
 class StateOptionsDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<StateOptions>
@@ -155,10 +161,25 @@ static void InitDefaultsStateItem() {
   ::dapr::proto::common::v1::StateItem::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<2> scc_info_StateItem =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 2, InitDefaultsStateItem}, {
+::google::protobuf::internal::SCCInfo<3> scc_info_StateItem =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 3, InitDefaultsStateItem}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_Etag.base,
       &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateItem_MetadataEntry_DoNotUse.base,
       &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateOptions.base,}};
+
+static void InitDefaultsEtag() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::common::v1::_Etag_default_instance_;
+    new (ptr) ::dapr::proto::common::v1::Etag();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::common::v1::Etag::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_Etag =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsEtag}, {}};
 
 static void InitDefaultsStateOptions() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -181,10 +202,11 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_StateItem_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_StateItem.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_Etag.base);
   ::google::protobuf::internal::InitSCC(&scc_info_StateOptions.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[7];
+::google::protobuf::Metadata file_level_metadata[8];
 const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[3];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
@@ -240,6 +262,12 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::StateItem, metadata_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::StateItem, options_),
   ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::Etag, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::Etag, value_),
+  ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::StateOptions, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -254,7 +282,8 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 25, -1, sizeof(::dapr::proto::common::v1::InvokeResponse)},
   { 32, 39, sizeof(::dapr::proto::common::v1::StateItem_MetadataEntry_DoNotUse)},
   { 41, -1, sizeof(::dapr::proto::common::v1::StateItem)},
-  { 51, -1, sizeof(::dapr::proto::common::v1::StateOptions)},
+  { 51, -1, sizeof(::dapr::proto::common::v1::Etag)},
+  { 57, -1, sizeof(::dapr::proto::common::v1::StateOptions)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -264,6 +293,7 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_InvokeResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_StateItem_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_StateItem_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_Etag_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_StateOptions_default_instance_),
 };
 
@@ -282,7 +312,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 7);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 8);
 }
 
 void AddDescriptorsImpl() {
@@ -303,28 +333,29 @@ void AddDescriptorsImpl() {
       "(\t\022;\n\016http_extension\030\004 \001(\0132#.dapr.proto."
       "common.v1.HTTPExtension\"J\n\016InvokeRespons"
       "e\022\"\n\004data\030\001 \001(\0132\024.google.protobuf.Any\022\024\n"
-      "\014content_type\030\002 \001(\t\"\334\001\n\tStateItem\022\013\n\003key"
-      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\014\022\014\n\004etag\030\003 \001(\t\022\?\n\010m"
-      "etadata\030\004 \003(\0132-.dapr.proto.common.v1.Sta"
-      "teItem.MetadataEntry\0223\n\007options\030\005 \001(\0132\"."
-      "dapr.proto.common.v1.StateOptions\032/\n\rMet"
-      "adataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
-      "8\001\"\357\002\n\014StateOptions\022H\n\013concurrency\030\001 \001(\016"
-      "23.dapr.proto.common.v1.StateOptions.Sta"
-      "teConcurrency\022H\n\013consistency\030\002 \001(\01623.dap"
-      "r.proto.common.v1.StateOptions.StateCons"
-      "istency\"h\n\020StateConcurrency\022\033\n\027CONCURREN"
-      "CY_UNSPECIFIED\020\000\022\033\n\027CONCURRENCY_FIRST_WR"
-      "ITE\020\001\022\032\n\026CONCURRENCY_LAST_WRITE\020\002\"a\n\020Sta"
-      "teConsistency\022\033\n\027CONSISTENCY_UNSPECIFIED"
-      "\020\000\022\030\n\024CONSISTENCY_EVENTUAL\020\001\022\026\n\022CONSISTE"
-      "NCY_STRONG\020\002Bi\n\nio.dapr.v1B\014CommonProtos"
-      "Z/github.com/dapr/dapr/pkg/proto/common/"
-      "v1;common\252\002\033Dapr.Client.Autogen.Grpc.v1b"
-      "\006proto3"
+      "\014content_type\030\002 \001(\t\"\370\001\n\tStateItem\022\013\n\003key"
+      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\014\022(\n\004etag\030\003 \001(\0132\032.da"
+      "pr.proto.common.v1.Etag\022\?\n\010metadata\030\004 \003("
+      "\0132-.dapr.proto.common.v1.StateItem.Metad"
+      "ataEntry\0223\n\007options\030\005 \001(\0132\".dapr.proto.c"
+      "ommon.v1.StateOptions\032/\n\rMetadataEntry\022\013"
+      "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\025\n\004Etag\022\r"
+      "\n\005value\030\001 \001(\t\"\357\002\n\014StateOptions\022H\n\013concur"
+      "rency\030\001 \001(\01623.dapr.proto.common.v1.State"
+      "Options.StateConcurrency\022H\n\013consistency\030"
+      "\002 \001(\01623.dapr.proto.common.v1.StateOption"
+      "s.StateConsistency\"h\n\020StateConcurrency\022\033"
+      "\n\027CONCURRENCY_UNSPECIFIED\020\000\022\033\n\027CONCURREN"
+      "CY_FIRST_WRITE\020\001\022\032\n\026CONCURRENCY_LAST_WRI"
+      "TE\020\002\"a\n\020StateConsistency\022\033\n\027CONSISTENCY_"
+      "UNSPECIFIED\020\000\022\030\n\024CONSISTENCY_EVENTUAL\020\001\022"
+      "\026\n\022CONSISTENCY_STRONG\020\002Bi\n\nio.dapr.v1B\014C"
+      "ommonProtosZ/github.com/dapr/dapr/pkg/pr"
+      "oto/common/v1;common\252\002\033Dapr.Client.Autog"
+      "en.Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 1327);
+      descriptor, 1378);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/common/v1/common.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();
@@ -1550,6 +1581,8 @@ void StateItem_MetadataEntry_DoNotUse::MergeFrom(
 // ===================================================================
 
 void StateItem::InitAsDefaultInstance() {
+  ::dapr::proto::common::v1::_StateItem_default_instance_._instance.get_mutable()->etag_ = const_cast< ::dapr::proto::common::v1::Etag*>(
+      ::dapr::proto::common::v1::Etag::internal_default_instance());
   ::dapr::proto::common::v1::_StateItem_default_instance_._instance.get_mutable()->options_ = const_cast< ::dapr::proto::common::v1::StateOptions*>(
       ::dapr::proto::common::v1::StateOptions::internal_default_instance());
 }
@@ -1581,9 +1614,10 @@ StateItem::StateItem(const StateItem& from)
   if (from.value().size() > 0) {
     value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
   }
-  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.etag().size() > 0) {
-    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  if (from.has_etag()) {
+    etag_ = new ::dapr::proto::common::v1::Etag(*from.etag_);
+  } else {
+    etag_ = NULL;
   }
   if (from.has_options()) {
     options_ = new ::dapr::proto::common::v1::StateOptions(*from.options_);
@@ -1596,8 +1630,9 @@ StateItem::StateItem(const StateItem& from)
 void StateItem::SharedCtor() {
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  ::memset(&etag_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&options_) -
+      reinterpret_cast<char*>(&etag_)) + sizeof(options_));
 }
 
 StateItem::~StateItem() {
@@ -1608,7 +1643,7 @@ StateItem::~StateItem() {
 void StateItem::SharedDtor() {
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete etag_;
   if (this != internal_default_instance()) delete options_;
 }
 
@@ -1635,7 +1670,10 @@ void StateItem::Clear() {
   metadata_.Clear();
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (GetArenaNoVirtual() == NULL && etag_ != NULL) {
+    delete etag_;
+  }
+  etag_ = NULL;
   if (GetArenaNoVirtual() == NULL && options_ != NULL) {
     delete options_;
   }
@@ -1681,16 +1719,12 @@ bool StateItem::MergePartialFromCodedStream(
         break;
       }
 
-      // string etag = 3;
+      // .dapr.proto.common.v1.Etag etag = 3;
       case 3: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
-                input, this->mutable_etag()));
-          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-            this->etag().data(), static_cast<int>(this->etag().length()),
-            ::google::protobuf::internal::WireFormatLite::PARSE,
-            "dapr.proto.common.v1.StateItem.etag"));
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_etag()));
         } else {
           goto handle_unusual;
         }
@@ -1778,14 +1812,10 @@ void StateItem::SerializeWithCachedSizes(
       2, this->value(), output);
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->etag().data(), static_cast<int>(this->etag().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "dapr.proto.common.v1.StateItem.etag");
-    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
-      3, this->etag(), output);
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->_internal_etag(), output);
   }
 
   // map<string, string> metadata = 4;
@@ -1879,15 +1909,11 @@ void StateItem::SerializeWithCachedSizes(
         2, this->value(), target);
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->etag().data(), static_cast<int>(this->etag().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "dapr.proto.common.v1.StateItem.etag");
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
-        3, this->etag(), target);
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        3, this->_internal_etag(), deterministic, target);
   }
 
   // map<string, string> metadata = 4;
@@ -1999,11 +2025,11 @@ size_t StateItem::ByteSizeLong() const {
         this->value());
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::StringSize(
-        this->etag());
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *etag_);
   }
 
   // .dapr.proto.common.v1.StateOptions options = 5;
@@ -2049,9 +2075,8 @@ void StateItem::MergeFrom(const StateItem& from) {
 
     value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
   }
-  if (from.etag().size() > 0) {
-
-    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  if (from.has_etag()) {
+    mutable_etag()->::dapr::proto::common::v1::Etag::MergeFrom(from.etag());
   }
   if (from.has_options()) {
     mutable_options()->::dapr::proto::common::v1::StateOptions::MergeFrom(from.options());
@@ -2087,13 +2112,254 @@ void StateItem::InternalSwap(StateItem* other) {
     GetArenaNoVirtual());
   value_.Swap(&other->value_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
-  etag_.Swap(&other->etag_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
+  swap(etag_, other->etag_);
   swap(options_, other->options_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
 ::google::protobuf::Metadata StateItem::GetMetadata() const {
+  protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void Etag::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int Etag::kValueFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+Etag::Etag()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_Etag.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.common.v1.Etag)
+}
+Etag::Etag(const Etag& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.value().size() > 0) {
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.common.v1.Etag)
+}
+
+void Etag::SharedCtor() {
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+Etag::~Etag() {
+  // @@protoc_insertion_point(destructor:dapr.proto.common.v1.Etag)
+  SharedDtor();
+}
+
+void Etag::SharedDtor() {
+  value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void Etag::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* Etag::descriptor() {
+  ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const Etag& Etag::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_Etag.base);
+  return *internal_default_instance();
+}
+
+
+void Etag::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.common.v1.Etag)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool Etag::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.common.v1.Etag)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string value = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_value()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->value().data(), static_cast<int>(this->value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.Etag.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.common.v1.Etag)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.common.v1.Etag)
+  return false;
+#undef DO_
+}
+
+void Etag::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.common.v1.Etag)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string value = 1;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.Etag.value");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->value(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.common.v1.Etag)
+}
+
+::google::protobuf::uint8* Etag::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.common.v1.Etag)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string value = 1;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.Etag.value");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->value(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.common.v1.Etag)
+  return target;
+}
+
+size_t Etag::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.common.v1.Etag)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string value = 1;
+  if (this->value().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->value());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void Etag::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.common.v1.Etag)
+  GOOGLE_DCHECK_NE(&from, this);
+  const Etag* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const Etag>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.common.v1.Etag)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.common.v1.Etag)
+    MergeFrom(*source);
+  }
+}
+
+void Etag::MergeFrom(const Etag& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.common.v1.Etag)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.value().size() > 0) {
+
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+}
+
+void Etag::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.common.v1.Etag)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void Etag::CopyFrom(const Etag& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.common.v1.Etag)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool Etag::IsInitialized() const {
+  return true;
+}
+
+void Etag::Swap(Etag* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void Etag::InternalSwap(Etag* other) {
+  using std::swap;
+  value_.Swap(&other->value_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata Etag::GetMetadata() const {
   protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -2392,6 +2658,9 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::StateIt
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::StateItem* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::StateItem >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::common::v1::StateItem >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::Etag* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::Etag >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::common::v1::Etag >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::StateOptions* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::StateOptions >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::common::v1::StateOptions >(arena);

--- a/src/dapr/proto/common/v1/common.pb.h
+++ b/src/dapr/proto/common/v1/common.pb.h
@@ -43,7 +43,7 @@ namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[7];
+  static const ::google::protobuf::internal::ParseTable schema[8];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -54,6 +54,9 @@ namespace dapr {
 namespace proto {
 namespace common {
 namespace v1 {
+class Etag;
+class EtagDefaultTypeInternal;
+extern EtagDefaultTypeInternal _Etag_default_instance_;
 class HTTPExtension;
 class HTTPExtensionDefaultTypeInternal;
 extern HTTPExtensionDefaultTypeInternal _HTTPExtension_default_instance_;
@@ -81,6 +84,7 @@ extern StateOptionsDefaultTypeInternal _StateOptions_default_instance_;
 }  // namespace dapr
 namespace google {
 namespace protobuf {
+template<> ::dapr::proto::common::v1::Etag* Arena::CreateMaybeMessage<::dapr::proto::common::v1::Etag>(Arena*);
 template<> ::dapr::proto::common::v1::HTTPExtension* Arena::CreateMaybeMessage<::dapr::proto::common::v1::HTTPExtension>(Arena*);
 template<> ::dapr::proto::common::v1::HTTPExtension_QuerystringEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::common::v1::HTTPExtension_QuerystringEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::common::v1::InvokeRequest* Arena::CreateMaybeMessage<::dapr::proto::common::v1::InvokeRequest>(Arena*);
@@ -771,19 +775,17 @@ class StateItem : public ::google::protobuf::Message /* @@protoc_insertion_point
   ::std::string* release_value();
   void set_allocated_value(::std::string* value);
 
-  // string etag = 3;
+  // .dapr.proto.common.v1.Etag etag = 3;
+  bool has_etag() const;
   void clear_etag();
   static const int kEtagFieldNumber = 3;
-  const ::std::string& etag() const;
-  void set_etag(const ::std::string& value);
-  #if LANG_CXX11
-  void set_etag(::std::string&& value);
-  #endif
-  void set_etag(const char* value);
-  void set_etag(const char* value, size_t size);
-  ::std::string* mutable_etag();
-  ::std::string* release_etag();
-  void set_allocated_etag(::std::string* etag);
+  private:
+  const ::dapr::proto::common::v1::Etag& _internal_etag() const;
+  public:
+  const ::dapr::proto::common::v1::Etag& etag() const;
+  ::dapr::proto::common::v1::Etag* release_etag();
+  ::dapr::proto::common::v1::Etag* mutable_etag();
+  void set_allocated_etag(::dapr::proto::common::v1::Etag* etag);
 
   // .dapr.proto.common.v1.StateOptions options = 5;
   bool has_options() const;
@@ -809,8 +811,119 @@ class StateItem : public ::google::protobuf::Message /* @@protoc_insertion_point
       0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr value_;
-  ::google::protobuf::internal::ArenaStringPtr etag_;
+  ::dapr::proto::common::v1::Etag* etag_;
   ::dapr::proto::common::v1::StateOptions* options_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class Etag : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.common.v1.Etag) */ {
+ public:
+  Etag();
+  virtual ~Etag();
+
+  Etag(const Etag& from);
+
+  inline Etag& operator=(const Etag& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  Etag(Etag&& from) noexcept
+    : Etag() {
+    *this = ::std::move(from);
+  }
+
+  inline Etag& operator=(Etag&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const Etag& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const Etag* internal_default_instance() {
+    return reinterpret_cast<const Etag*>(
+               &_Etag_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    6;
+
+  void Swap(Etag* other);
+  friend void swap(Etag& a, Etag& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline Etag* New() const final {
+    return CreateMaybeMessage<Etag>(NULL);
+  }
+
+  Etag* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<Etag>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const Etag& from);
+  void MergeFrom(const Etag& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(Etag* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string value = 1;
+  void clear_value();
+  static const int kValueFieldNumber = 1;
+  const ::std::string& value() const;
+  void set_value(const ::std::string& value);
+  #if LANG_CXX11
+  void set_value(::std::string&& value);
+  #endif
+  void set_value(const char* value);
+  void set_value(const char* value, size_t size);
+  ::std::string* mutable_value();
+  ::std::string* release_value();
+  void set_allocated_value(::std::string* value);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.common.v1.Etag)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr value_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::TableStruct;
 };
@@ -851,7 +964,7 @@ class StateOptions : public ::google::protobuf::Message /* @@protoc_insertion_po
                &_StateOptions_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    7;
 
   void Swap(StateOptions* other);
   friend void swap(StateOptions& a, StateOptions& b) {
@@ -1454,56 +1567,57 @@ inline void StateItem::set_allocated_value(::std::string* value) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.StateItem.value)
 }
 
-// string etag = 3;
+// .dapr.proto.common.v1.Etag etag = 3;
+inline bool StateItem::has_etag() const {
+  return this != internal_default_instance() && etag_ != NULL;
+}
 inline void StateItem::clear_etag() {
-  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (GetArenaNoVirtual() == NULL && etag_ != NULL) {
+    delete etag_;
+  }
+  etag_ = NULL;
 }
-inline const ::std::string& StateItem::etag() const {
+inline const ::dapr::proto::common::v1::Etag& StateItem::_internal_etag() const {
+  return *etag_;
+}
+inline const ::dapr::proto::common::v1::Etag& StateItem::etag() const {
+  const ::dapr::proto::common::v1::Etag* p = etag_;
   // @@protoc_insertion_point(field_get:dapr.proto.common.v1.StateItem.etag)
-  return etag_.GetNoArena();
+  return p != NULL ? *p : *reinterpret_cast<const ::dapr::proto::common::v1::Etag*>(
+      &::dapr::proto::common::v1::_Etag_default_instance_);
 }
-inline void StateItem::set_etag(const ::std::string& value) {
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:dapr.proto.common.v1.StateItem.etag)
-}
-#if LANG_CXX11
-inline void StateItem::set_etag(::std::string&& value) {
-  
-  etag_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.common.v1.StateItem.etag)
-}
-#endif
-inline void StateItem::set_etag(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:dapr.proto.common.v1.StateItem.etag)
-}
-inline void StateItem::set_etag(const char* value, size_t size) {
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:dapr.proto.common.v1.StateItem.etag)
-}
-inline ::std::string* StateItem::mutable_etag() {
-  
-  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.StateItem.etag)
-  return etag_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* StateItem::release_etag() {
+inline ::dapr::proto::common::v1::Etag* StateItem::release_etag() {
   // @@protoc_insertion_point(field_release:dapr.proto.common.v1.StateItem.etag)
   
-  return etag_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::dapr::proto::common::v1::Etag* temp = etag_;
+  etag_ = NULL;
+  return temp;
 }
-inline void StateItem::set_allocated_etag(::std::string* etag) {
-  if (etag != NULL) {
+inline ::dapr::proto::common::v1::Etag* StateItem::mutable_etag() {
+  
+  if (etag_ == NULL) {
+    auto* p = CreateMaybeMessage<::dapr::proto::common::v1::Etag>(GetArenaNoVirtual());
+    etag_ = p;
+  }
+  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.StateItem.etag)
+  return etag_;
+}
+inline void StateItem::set_allocated_etag(::dapr::proto::common::v1::Etag* etag) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete etag_;
+  }
+  if (etag) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      etag = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, etag, submessage_arena);
+    }
     
   } else {
     
   }
-  etag_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), etag);
+  etag_ = etag;
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.StateItem.etag)
 }
 
@@ -1581,6 +1695,63 @@ inline void StateItem::set_allocated_options(::dapr::proto::common::v1::StateOpt
 
 // -------------------------------------------------------------------
 
+// Etag
+
+// string value = 1;
+inline void Etag::clear_value() {
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& Etag::value() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.common.v1.Etag.value)
+  return value_.GetNoArena();
+}
+inline void Etag::set_value(const ::std::string& value) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.common.v1.Etag.value)
+}
+#if LANG_CXX11
+inline void Etag::set_value(::std::string&& value) {
+  
+  value_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.common.v1.Etag.value)
+}
+#endif
+inline void Etag::set_value(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.common.v1.Etag.value)
+}
+inline void Etag::set_value(const char* value, size_t size) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.common.v1.Etag.value)
+}
+inline ::std::string* Etag::mutable_value() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.Etag.value)
+  return value_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* Etag::release_value() {
+  // @@protoc_insertion_point(field_release:dapr.proto.common.v1.Etag.value)
+  
+  return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void Etag::set_allocated_value(::std::string* value) {
+  if (value != NULL) {
+    
+  } else {
+    
+  }
+  value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.Etag.value)
+}
+
+// -------------------------------------------------------------------
+
 // StateOptions
 
 // .dapr.proto.common.v1.StateOptions.StateConcurrency concurrency = 1;
@@ -1614,6 +1785,8 @@ inline void StateOptions::set_consistency(::dapr::proto::common::v1::StateOption
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/dapr/proto/runtime/v1/appcallback.pb.cc
+++ b/src/dapr/proto/runtime/v1/appcallback.pb.cc
@@ -20,7 +20,7 @@
 // @@protoc_insertion_point(includes)
 
 namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
-extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<2> scc_info_StateItem;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<3> scc_info_StateItem;
 }  // namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto
 namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto {
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_BindingEventRequest_MetadataEntry_DoNotUse;

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
@@ -26,6 +26,7 @@ static const char* Dapr_method_names[] = {
   "/dapr.proto.runtime.v1.Dapr/GetBulkState",
   "/dapr.proto.runtime.v1.Dapr/SaveState",
   "/dapr.proto.runtime.v1.Dapr/DeleteState",
+  "/dapr.proto.runtime.v1.Dapr/DeleteBulkState",
   "/dapr.proto.runtime.v1.Dapr/ExecuteStateTransaction",
   "/dapr.proto.runtime.v1.Dapr/PublishEvent",
   "/dapr.proto.runtime.v1.Dapr/InvokeBinding",
@@ -38,6 +39,8 @@ static const char* Dapr_method_names[] = {
   "/dapr.proto.runtime.v1.Dapr/GetActorState",
   "/dapr.proto.runtime.v1.Dapr/ExecuteActorStateTransaction",
   "/dapr.proto.runtime.v1.Dapr/InvokeActor",
+  "/dapr.proto.runtime.v1.Dapr/GetMetadata",
+  "/dapr.proto.runtime.v1.Dapr/SetMetadata",
 };
 
 std::unique_ptr< Dapr::Stub> Dapr::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -52,18 +55,21 @@ Dapr::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   , rpcmethod_GetBulkState_(Dapr_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SaveState_(Dapr_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_DeleteState_(Dapr_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ExecuteStateTransaction_(Dapr_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_PublishEvent_(Dapr_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_InvokeBinding_(Dapr_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetSecret_(Dapr_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetBulkSecret_(Dapr_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RegisterActorTimer_(Dapr_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UnregisterActorTimer_(Dapr_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RegisterActorReminder_(Dapr_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UnregisterActorReminder_(Dapr_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetActorState_(Dapr_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ExecuteActorStateTransaction_(Dapr_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_InvokeActor_(Dapr_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DeleteBulkState_(Dapr_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ExecuteStateTransaction_(Dapr_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PublishEvent_(Dapr_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_InvokeBinding_(Dapr_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetSecret_(Dapr_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetBulkSecret_(Dapr_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RegisterActorTimer_(Dapr_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UnregisterActorTimer_(Dapr_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RegisterActorReminder_(Dapr_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UnregisterActorReminder_(Dapr_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetActorState_(Dapr_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ExecuteActorStateTransaction_(Dapr_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_InvokeActor_(Dapr_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetMetadata_(Dapr_method_names[18], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetMetadata_(Dapr_method_names[19], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status Dapr::Stub::InvokeService(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeServiceRequest& request, ::dapr::proto::common::v1::InvokeResponse* response) {
@@ -144,6 +150,22 @@ void Dapr::Stub::experimental_async::DeleteState(::grpc::ClientContext* context,
 
 ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::PrepareAsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_DeleteState_, context, request, false);
+}
+
+::grpc::Status Dapr::Stub::DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_DeleteBulkState_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_DeleteBulkState_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::AsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_DeleteBulkState_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::PrepareAsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_DeleteBulkState_, context, request, false);
 }
 
 ::grpc::Status Dapr::Stub::ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::google::protobuf::Empty* response) {
@@ -338,6 +360,38 @@ void Dapr::Stub::experimental_async::InvokeActor(::grpc::ClientContext* context,
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::InvokeActorResponse>::Create(channel_.get(), cq, rpcmethod_InvokeActor_, context, request, false);
 }
 
+::grpc::Status Dapr::Stub::GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetMetadata_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetMetadata_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* Dapr::Stub::AsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::GetMetadataResponse>::Create(channel_.get(), cq, rpcmethod_GetMetadata_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* Dapr::Stub::PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::GetMetadataResponse>::Create(channel_.get(), cq, rpcmethod_GetMetadata_, context, request, false);
+}
+
+::grpc::Status Dapr::Stub::SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_SetMetadata_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_SetMetadata_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_SetMetadata_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::PrepareAsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_SetMetadata_, context, request, false);
+}
+
 Dapr::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Dapr_method_names[0],
@@ -367,63 +421,78 @@ Dapr::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Dapr_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::DeleteBulkStateRequest, ::google::protobuf::Empty>(
+          std::mem_fn(&Dapr::Service::DeleteBulkState), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[6],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::ExecuteStateTransaction), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[6],
+      Dapr_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::PublishEventRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::PublishEvent), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[7],
+      Dapr_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::InvokeBindingRequest, ::dapr::proto::runtime::v1::InvokeBindingResponse>(
           std::mem_fn(&Dapr::Service::InvokeBinding), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[8],
+      Dapr_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetSecretRequest, ::dapr::proto::runtime::v1::GetSecretResponse>(
           std::mem_fn(&Dapr::Service::GetSecret), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[9],
+      Dapr_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetBulkSecretRequest, ::dapr::proto::runtime::v1::GetBulkSecretResponse>(
           std::mem_fn(&Dapr::Service::GetBulkSecret), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[10],
+      Dapr_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::RegisterActorTimerRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::RegisterActorTimer), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[11],
+      Dapr_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::UnregisterActorTimerRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::UnregisterActorTimer), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[12],
+      Dapr_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::RegisterActorReminderRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::RegisterActorReminder), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[13],
+      Dapr_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::UnregisterActorReminderRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::UnregisterActorReminder), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[14],
+      Dapr_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetActorStateRequest, ::dapr::proto::runtime::v1::GetActorStateResponse>(
           std::mem_fn(&Dapr::Service::GetActorState), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[15],
+      Dapr_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::ExecuteActorStateTransaction), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[16],
+      Dapr_method_names[17],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::InvokeActorRequest, ::dapr::proto::runtime::v1::InvokeActorResponse>(
           std::mem_fn(&Dapr::Service::InvokeActor), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[18],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::google::protobuf::Empty, ::dapr::proto::runtime::v1::GetMetadataResponse>(
+          std::mem_fn(&Dapr::Service::GetMetadata), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[19],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::SetMetadataRequest, ::google::protobuf::Empty>(
+          std::mem_fn(&Dapr::Service::SetMetadata), this)));
 }
 
 Dapr::Service::~Service() {
@@ -458,6 +527,13 @@ Dapr::Service::~Service() {
 }
 
 ::grpc::Status Dapr::Service::DeleteState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;
@@ -542,6 +618,20 @@ Dapr::Service::~Service() {
 }
 
 ::grpc::Status Dapr::Service::InvokeActor(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
@@ -85,6 +85,14 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncDeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncDeleteStateRaw(context, request, cq));
     }
+    // Deletes a bulk of state items for a list of keys
+    virtual ::grpc::Status DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncDeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncDeleteBulkStateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncDeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncDeleteBulkStateRaw(context, request, cq));
+    }
     // Executes transactions for a specified store
     virtual ::grpc::Status ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::google::protobuf::Empty* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) {
@@ -181,6 +189,22 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>> PrepareAsyncInvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>>(PrepareAsyncInvokeActorRaw(context, request, cq));
     }
+    // Gets metadata of the sidecar
+    virtual ::grpc::Status GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>> AsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>>(AsyncGetMetadataRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>> PrepareAsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>>(PrepareAsyncGetMetadataRaw(context, request, cq));
+    }
+    // Sets value in extended metadata of the sidecar
+    virtual ::grpc::Status SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncSetMetadataRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncSetMetadataRaw(context, request, cq));
+    }
     class experimental_async_interface {
      public:
       virtual ~experimental_async_interface() {}
@@ -194,6 +218,8 @@ class Dapr final {
       virtual void SaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // Deletes the state for a specific key.
       virtual void DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      // Deletes a bulk of state items for a list of keys
+      virtual void DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // Executes transactions for a specified store
       virtual void ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // Publishes events to the specific topic.
@@ -218,6 +244,10 @@ class Dapr final {
       virtual void ExecuteActorStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // InvokeActor calls a method on an actor.
       virtual void InvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response, std::function<void(::grpc::Status)>) = 0;
+      // Gets metadata of the sidecar
+      virtual void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) = 0;
+      // Sets value in extended metadata of the sidecar
+      virtual void SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
     };
     virtual class experimental_async_interface* experimental_async() { return nullptr; }
   private:
@@ -231,6 +261,8 @@ class Dapr final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncExecuteStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncExecuteStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncPublishEventRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::PublishEventRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -255,6 +287,10 @@ class Dapr final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncExecuteActorStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>* AsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>* PrepareAsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>* AsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -293,6 +329,13 @@ class Dapr final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncDeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncDeleteStateRaw(context, request, cq));
+    }
+    ::grpc::Status DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncDeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncDeleteBulkStateRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncDeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncDeleteBulkStateRaw(context, request, cq));
     }
     ::grpc::Status ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::google::protobuf::Empty* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) {
@@ -378,6 +421,20 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>> PrepareAsyncInvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>>(PrepareAsyncInvokeActorRaw(context, request, cq));
     }
+    ::grpc::Status GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>> AsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>>(AsyncGetMetadataRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>> PrepareAsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>>(PrepareAsyncGetMetadataRaw(context, request, cq));
+    }
+    ::grpc::Status SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncSetMetadataRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncSetMetadataRaw(context, request, cq));
+    }
     class experimental_async final :
       public StubInterface::experimental_async_interface {
      public:
@@ -386,6 +443,7 @@ class Dapr final {
       void GetBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest* request, ::dapr::proto::runtime::v1::GetBulkStateResponse* response, std::function<void(::grpc::Status)>) override;
       void SaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void PublishEvent(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::PublishEventRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void InvokeBinding(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeBindingRequest* request, ::dapr::proto::runtime::v1::InvokeBindingResponse* response, std::function<void(::grpc::Status)>) override;
@@ -398,6 +456,8 @@ class Dapr final {
       void GetActorState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetActorStateRequest* request, ::dapr::proto::runtime::v1::GetActorStateResponse* response, std::function<void(::grpc::Status)>) override;
       void ExecuteActorStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void InvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response, std::function<void(::grpc::Status)>) override;
+      void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) override;
+      void SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
      private:
       friend class Stub;
       explicit experimental_async(Stub* stub): stub_(stub) { }
@@ -419,6 +479,8 @@ class Dapr final {
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncExecuteStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncExecuteStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncPublishEventRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::PublishEventRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -443,11 +505,16 @@ class Dapr final {
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncExecuteActorStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>* AsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>* PrepareAsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* AsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_InvokeService_;
     const ::grpc::internal::RpcMethod rpcmethod_GetState_;
     const ::grpc::internal::RpcMethod rpcmethod_GetBulkState_;
     const ::grpc::internal::RpcMethod rpcmethod_SaveState_;
     const ::grpc::internal::RpcMethod rpcmethod_DeleteState_;
+    const ::grpc::internal::RpcMethod rpcmethod_DeleteBulkState_;
     const ::grpc::internal::RpcMethod rpcmethod_ExecuteStateTransaction_;
     const ::grpc::internal::RpcMethod rpcmethod_PublishEvent_;
     const ::grpc::internal::RpcMethod rpcmethod_InvokeBinding_;
@@ -460,6 +527,8 @@ class Dapr final {
     const ::grpc::internal::RpcMethod rpcmethod_GetActorState_;
     const ::grpc::internal::RpcMethod rpcmethod_ExecuteActorStateTransaction_;
     const ::grpc::internal::RpcMethod rpcmethod_InvokeActor_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetMetadata_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetMetadata_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -477,6 +546,8 @@ class Dapr final {
     virtual ::grpc::Status SaveState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response);
     // Deletes the state for a specific key.
     virtual ::grpc::Status DeleteState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response);
+    // Deletes a bulk of state items for a list of keys
+    virtual ::grpc::Status DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response);
     // Executes transactions for a specified store
     virtual ::grpc::Status ExecuteStateTransaction(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::google::protobuf::Empty* response);
     // Publishes events to the specific topic.
@@ -501,6 +572,10 @@ class Dapr final {
     virtual ::grpc::Status ExecuteActorStateTransaction(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response);
     // InvokeActor calls a method on an actor.
     virtual ::grpc::Status InvokeActor(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response);
+    // Gets metadata of the sidecar
+    virtual ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response);
+    // Sets value in extended metadata of the sidecar
+    virtual ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_InvokeService : public BaseClass {
@@ -603,12 +678,32 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_DeleteBulkState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_DeleteBulkState() {
+      ::grpc::Service::MarkMethodAsync(5);
+    }
+    ~WithAsyncMethod_DeleteBulkState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestDeleteBulkState(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_ExecuteStateTransaction : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -619,7 +714,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteStateTransaction(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -628,7 +723,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -639,7 +734,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPublishEvent(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::PublishEventRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -648,7 +743,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -659,7 +754,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeBinding(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::InvokeBindingRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::InvokeBindingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -668,7 +763,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetSecret() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -679,7 +774,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSecret(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetSecretRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetSecretResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -688,7 +783,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -699,7 +794,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetBulkSecret(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetBulkSecretRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetBulkSecretResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -708,7 +803,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -719,7 +814,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorTimer(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::RegisterActorTimerRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -728,7 +823,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -739,7 +834,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorTimer(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::UnregisterActorTimerRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -748,7 +843,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -759,7 +854,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorReminder(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::RegisterActorReminderRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -768,7 +863,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -779,7 +874,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorReminder(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::UnregisterActorReminderRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -788,7 +883,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetActorState() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -799,7 +894,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetActorState(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetActorStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetActorStateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -808,7 +903,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -819,7 +914,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteActorStateTransaction(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -828,7 +923,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodAsync(16);
+      ::grpc::Service::MarkMethodAsync(17);
     }
     ~WithAsyncMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -839,10 +934,50 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeActor(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::InvokeActorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_DeleteState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<Service > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_GetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_GetMetadata() {
+      ::grpc::Service::MarkMethodAsync(18);
+    }
+    ~WithAsyncMethod_GetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetMetadata(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetMetadataResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_SetMetadata() {
+      ::grpc::Service::MarkMethodAsync(19);
+    }
+    ~WithAsyncMethod_SetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetMetadata(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_DeleteState<WithAsyncMethod_DeleteBulkState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<WithAsyncMethod_GetMetadata<WithAsyncMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithGenericMethod_InvokeService : public BaseClass {
    private:
@@ -929,12 +1064,29 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_DeleteBulkState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_DeleteBulkState() {
+      ::grpc::Service::MarkMethodGeneric(5);
+    }
+    ~WithGenericMethod_DeleteBulkState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_ExecuteStateTransaction : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -951,7 +1103,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -968,7 +1120,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -985,7 +1137,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetSecret() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1002,7 +1154,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1019,7 +1171,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1036,7 +1188,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1053,7 +1205,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1070,7 +1222,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1087,7 +1239,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetActorState() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1104,7 +1256,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1121,13 +1273,47 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodGeneric(16);
+      ::grpc::Service::MarkMethodGeneric(17);
     }
     ~WithGenericMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
     ::grpc::Status InvokeActor(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_GetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_GetMetadata() {
+      ::grpc::Service::MarkMethodGeneric(18);
+    }
+    ~WithGenericMethod_GetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_SetMetadata() {
+      ::grpc::Service::MarkMethodGeneric(19);
+    }
+    ~WithGenericMethod_SetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1233,12 +1419,32 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_DeleteBulkState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_DeleteBulkState() {
+      ::grpc::Service::MarkMethodRaw(5);
+    }
+    ~WithRawMethod_DeleteBulkState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestDeleteBulkState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_ExecuteStateTransaction : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1249,7 +1455,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteStateTransaction(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1258,7 +1464,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1269,7 +1475,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPublishEvent(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1278,7 +1484,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1289,7 +1495,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeBinding(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1298,7 +1504,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetSecret() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1309,7 +1515,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSecret(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1318,7 +1524,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1329,7 +1535,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetBulkSecret(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1338,7 +1544,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1349,7 +1555,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorTimer(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1358,7 +1564,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1369,7 +1575,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorTimer(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1378,7 +1584,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1389,7 +1595,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorReminder(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1398,7 +1604,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1409,7 +1615,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorReminder(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1418,7 +1624,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetActorState() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1429,7 +1635,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetActorState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1438,7 +1644,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1449,7 +1655,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteActorStateTransaction(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1458,7 +1664,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodRaw(16);
+      ::grpc::Service::MarkMethodRaw(17);
     }
     ~WithRawMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1469,7 +1675,47 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeActor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_GetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_GetMetadata() {
+      ::grpc::Service::MarkMethodRaw(18);
+    }
+    ~WithRawMethod_GetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetMetadata(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_SetMetadata() {
+      ::grpc::Service::MarkMethodRaw(19);
+    }
+    ~WithRawMethod_SetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetMetadata(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1573,12 +1819,32 @@ class Dapr final {
     virtual ::grpc::Status StreamedDeleteState(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::DeleteStateRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_DeleteBulkState : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_DeleteBulkState() {
+      ::grpc::Service::MarkMethodStreamed(5,
+        new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::DeleteBulkStateRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_DeleteBulkState<BaseClass>::StreamedDeleteBulkState, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_DeleteBulkState() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status DeleteBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedDeleteBulkState(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::DeleteBulkStateRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_ExecuteStateTransaction : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_ExecuteStateTransaction<BaseClass>::StreamedExecuteStateTransaction, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_ExecuteStateTransaction() override {
@@ -1598,7 +1864,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::PublishEventRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_PublishEvent<BaseClass>::StreamedPublishEvent, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_PublishEvent() override {
@@ -1618,7 +1884,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::InvokeBindingRequest, ::dapr::proto::runtime::v1::InvokeBindingResponse>(std::bind(&WithStreamedUnaryMethod_InvokeBinding<BaseClass>::StreamedInvokeBinding, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_InvokeBinding() override {
@@ -1638,7 +1904,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetSecret() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetSecretRequest, ::dapr::proto::runtime::v1::GetSecretResponse>(std::bind(&WithStreamedUnaryMethod_GetSecret<BaseClass>::StreamedGetSecret, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetSecret() override {
@@ -1658,7 +1924,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetBulkSecretRequest, ::dapr::proto::runtime::v1::GetBulkSecretResponse>(std::bind(&WithStreamedUnaryMethod_GetBulkSecret<BaseClass>::StreamedGetBulkSecret, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetBulkSecret() override {
@@ -1678,7 +1944,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::RegisterActorTimerRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_RegisterActorTimer<BaseClass>::StreamedRegisterActorTimer, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_RegisterActorTimer() override {
@@ -1698,7 +1964,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::UnregisterActorTimerRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_UnregisterActorTimer<BaseClass>::StreamedUnregisterActorTimer, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_UnregisterActorTimer() override {
@@ -1718,7 +1984,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::RegisterActorReminderRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_RegisterActorReminder<BaseClass>::StreamedRegisterActorReminder, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_RegisterActorReminder() override {
@@ -1738,7 +2004,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::UnregisterActorReminderRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_UnregisterActorReminder<BaseClass>::StreamedUnregisterActorReminder, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_UnregisterActorReminder() override {
@@ -1758,7 +2024,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetActorState() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetActorStateRequest, ::dapr::proto::runtime::v1::GetActorStateResponse>(std::bind(&WithStreamedUnaryMethod_GetActorState<BaseClass>::StreamedGetActorState, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetActorState() override {
@@ -1778,7 +2044,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_ExecuteActorStateTransaction<BaseClass>::StreamedExecuteActorStateTransaction, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_ExecuteActorStateTransaction() override {
@@ -1798,7 +2064,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodStreamed(16,
+      ::grpc::Service::MarkMethodStreamed(17,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::InvokeActorRequest, ::dapr::proto::runtime::v1::InvokeActorResponse>(std::bind(&WithStreamedUnaryMethod_InvokeActor<BaseClass>::StreamedInvokeActor, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_InvokeActor() override {
@@ -1812,9 +2078,49 @@ class Dapr final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedInvokeActor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::InvokeActorRequest,::dapr::proto::runtime::v1::InvokeActorResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<Service > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_GetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_GetMetadata() {
+      ::grpc::Service::MarkMethodStreamed(18,
+        new ::grpc::internal::StreamedUnaryHandler< ::google::protobuf::Empty, ::dapr::proto::runtime::v1::GetMetadataResponse>(std::bind(&WithStreamedUnaryMethod_GetMetadata<BaseClass>::StreamedGetMetadata, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_GetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedGetMetadata(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::dapr::proto::runtime::v1::GetMetadataResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SetMetadata : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_SetMetadata() {
+      ::grpc::Service::MarkMethodStreamed(19,
+        new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::SetMetadataRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_SetMetadata<BaseClass>::StreamedSetMetadata, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_SetMetadata() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetMetadata(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::SetMetadataRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<Service > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace v1

--- a/src/dapr/proto/runtime/v1/dapr.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.pb.cc
@@ -20,17 +20,19 @@
 // @@protoc_insertion_point(includes)
 
 namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_Etag;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_StateOptions;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<2> scc_info_InvokeRequest;
-extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<2> scc_info_StateItem;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<3> scc_info_StateItem;
 }  // namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto
 namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto {
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_ActiveActorsCount;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_BulkStateItem_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_DeleteStateRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_ExecuteStateTransactionRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkSecretRequest_MetadataEntry_DoNotUse;
-extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkSecretResponse_DataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretResponse_DataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetStateRequest_MetadataEntry_DoNotUse;
@@ -38,7 +40,11 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2epr
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingResponse_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_PublishEventRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_RegisteredComponents;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_SecretResponse_SecretsEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_BulkStateItem;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_GetBulkSecretResponse_DataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_SecretResponse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_TransactionalActorStateOperation;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_TransactionalStateOperation;
 }  // namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto
@@ -109,6 +115,11 @@ class DeleteStateRequestDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<DeleteStateRequest>
       _instance;
 } _DeleteStateRequest_default_instance_;
+class DeleteBulkStateRequestDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<DeleteBulkStateRequest>
+      _instance;
+} _DeleteBulkStateRequest_default_instance_;
 class SaveStateRequestDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<SaveStateRequest>
@@ -174,6 +185,16 @@ class GetBulkSecretRequestDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<GetBulkSecretRequest>
       _instance;
 } _GetBulkSecretRequest_default_instance_;
+class SecretResponse_SecretsEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SecretResponse_SecretsEntry_DoNotUse>
+      _instance;
+} _SecretResponse_SecretsEntry_DoNotUse_default_instance_;
+class SecretResponseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SecretResponse>
+      _instance;
+} _SecretResponse_default_instance_;
 class GetBulkSecretResponse_DataEntry_DoNotUseDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<GetBulkSecretResponse_DataEntry_DoNotUse>
@@ -249,6 +270,31 @@ class InvokeActorResponseDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<InvokeActorResponse>
       _instance;
 } _InvokeActorResponse_default_instance_;
+class GetMetadataResponse_ExtendedMetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse>
+      _instance;
+} _GetMetadataResponse_ExtendedMetadataEntry_DoNotUse_default_instance_;
+class GetMetadataResponseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetMetadataResponse>
+      _instance;
+} _GetMetadataResponse_default_instance_;
+class ActiveActorsCountDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ActiveActorsCount>
+      _instance;
+} _ActiveActorsCount_default_instance_;
+class RegisteredComponentsDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<RegisteredComponents>
+      _instance;
+} _RegisteredComponents_default_instance_;
+class SetMetadataRequestDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SetMetadataRequest>
+      _instance;
+} _SetMetadataRequest_default_instance_;
 }  // namespace v1
 }  // namespace runtime
 }  // namespace proto
@@ -420,10 +466,26 @@ static void InitDefaultsDeleteStateRequest() {
   ::dapr::proto::runtime::v1::DeleteStateRequest::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<2> scc_info_DeleteStateRequest =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 2, InitDefaultsDeleteStateRequest}, {
+::google::protobuf::internal::SCCInfo<3> scc_info_DeleteStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 3, InitDefaultsDeleteStateRequest}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_Etag.base,
       &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateOptions.base,
       &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_DeleteStateRequest_MetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsDeleteBulkStateRequest() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_DeleteBulkStateRequest_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::DeleteBulkStateRequest();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::DeleteBulkStateRequest::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_DeleteBulkStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsDeleteBulkStateRequest}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateItem.base,}};
 
 static void InitDefaultsSaveStateRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -608,6 +670,34 @@ static void InitDefaultsGetBulkSecretRequest() {
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetBulkSecretRequest}, {
       &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetBulkSecretRequest_MetadataEntry_DoNotUse.base,}};
 
+static void InitDefaultsSecretResponse_SecretsEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SecretResponse_SecretsEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_SecretResponse_SecretsEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsSecretResponse_SecretsEntry_DoNotUse}, {}};
+
+static void InitDefaultsSecretResponse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SecretResponse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SecretResponse();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::SecretResponse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_SecretResponse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsSecretResponse}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SecretResponse_SecretsEntry_DoNotUse.base,}};
+
 static void InitDefaultsGetBulkSecretResponse_DataEntry_DoNotUse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -618,8 +708,9 @@ static void InitDefaultsGetBulkSecretResponse_DataEntry_DoNotUse() {
   ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkSecretResponse_DataEntry_DoNotUse =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetBulkSecretResponse_DataEntry_DoNotUse}, {}};
+::google::protobuf::internal::SCCInfo<1> scc_info_GetBulkSecretResponse_DataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetBulkSecretResponse_DataEntry_DoNotUse}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SecretResponse.base,}};
 
 static void InitDefaultsGetBulkSecretResponse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -822,6 +913,78 @@ static void InitDefaultsInvokeActorResponse() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeActorResponse =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsInvokeActorResponse}, {}};
 
+static void InitDefaultsGetMetadataResponse_ExtendedMetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetMetadataResponse_ExtendedMetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsGetMetadataResponse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetMetadataResponse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetMetadataResponse();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::GetMetadataResponse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<3> scc_info_GetMetadataResponse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 3, InitDefaultsGetMetadataResponse}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_ActiveActorsCount.base,
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_RegisteredComponents.base,
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsActiveActorsCount() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_ActiveActorsCount_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::ActiveActorsCount();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::ActiveActorsCount::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ActiveActorsCount =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsActiveActorsCount}, {}};
+
+static void InitDefaultsRegisteredComponents() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_RegisteredComponents_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::RegisteredComponents();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::RegisteredComponents::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_RegisteredComponents =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsRegisteredComponents}, {}};
+
+static void InitDefaultsSetMetadataRequest() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SetMetadataRequest_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SetMetadataRequest();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::SetMetadataRequest::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_SetMetadataRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsSetMetadataRequest}, {}};
+
 void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeServiceRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetStateRequest_MetadataEntry_DoNotUse.base);
@@ -835,6 +998,7 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_GetStateResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_DeleteStateRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_DeleteStateRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_DeleteBulkStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_SaveStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_PublishEventRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_PublishEventRequest.base);
@@ -848,6 +1012,8 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_GetSecretResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkSecretRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkSecretRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SecretResponse_SecretsEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SecretResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkSecretResponse_DataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetBulkSecretResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_TransactionalStateOperation.base);
@@ -863,9 +1029,14 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_TransactionalActorStateOperation.base);
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeActorRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeActorResponse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetMetadataResponse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ActiveActorsCount.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_RegisteredComponents.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SetMetadataRequest.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[40];
+::google::protobuf::Metadata file_level_metadata[48];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -972,6 +1143,13 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, etag_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, options_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteStateRequest, metadata_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteBulkStateRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteBulkStateRequest, store_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::DeleteBulkStateRequest, states_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SaveStateRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1080,6 +1258,21 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkSecretRequest, store_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkSecretRequest, metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SecretResponse, secrets_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse, _has_bits_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1203,6 +1396,46 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::InvokeActorResponse, data_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse, id_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse, active_actors_count_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse, registered_components_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetMetadataResponse, extended_metadata_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::ActiveActorsCount, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::ActiveActorsCount, type_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::ActiveActorsCount, count_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisteredComponents, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisteredComponents, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisteredComponents, type_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisteredComponents, version_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SetMetadataRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SetMetadataRequest, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SetMetadataRequest, value_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::runtime::v1::InvokeServiceRequest)},
@@ -1217,34 +1450,42 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 77, -1, sizeof(::dapr::proto::runtime::v1::GetStateResponse)},
   { 85, 92, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse)},
   { 94, -1, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest)},
-  { 104, -1, sizeof(::dapr::proto::runtime::v1::SaveStateRequest)},
-  { 111, 118, sizeof(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse)},
-  { 120, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
-  { 130, 137, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
-  { 139, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
-  { 148, 155, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
-  { 157, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
-  { 164, 171, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
-  { 173, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
-  { 181, 188, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
-  { 190, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
-  { 196, 203, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest_MetadataEntry_DoNotUse)},
-  { 205, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest)},
-  { 212, 219, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse)},
-  { 221, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse)},
-  { 227, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
-  { 234, 241, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
-  { 243, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
-  { 251, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorTimerRequest)},
-  { 263, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorTimerRequest)},
-  { 271, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorReminderRequest)},
-  { 282, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorReminderRequest)},
-  { 290, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateRequest)},
-  { 298, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateResponse)},
-  { 304, -1, sizeof(::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest)},
-  { 312, -1, sizeof(::dapr::proto::runtime::v1::TransactionalActorStateOperation)},
-  { 320, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorRequest)},
-  { 329, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorResponse)},
+  { 104, -1, sizeof(::dapr::proto::runtime::v1::DeleteBulkStateRequest)},
+  { 111, -1, sizeof(::dapr::proto::runtime::v1::SaveStateRequest)},
+  { 118, 125, sizeof(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse)},
+  { 127, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
+  { 137, 144, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
+  { 146, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
+  { 155, 162, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
+  { 164, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
+  { 171, 178, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
+  { 180, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
+  { 188, 195, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
+  { 197, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
+  { 203, 210, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest_MetadataEntry_DoNotUse)},
+  { 212, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest)},
+  { 219, 226, sizeof(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse)},
+  { 228, -1, sizeof(::dapr::proto::runtime::v1::SecretResponse)},
+  { 234, 241, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse)},
+  { 243, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse)},
+  { 249, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
+  { 256, 263, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
+  { 265, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
+  { 273, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorTimerRequest)},
+  { 285, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorTimerRequest)},
+  { 293, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorReminderRequest)},
+  { 304, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorReminderRequest)},
+  { 312, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateRequest)},
+  { 320, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateResponse)},
+  { 326, -1, sizeof(::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest)},
+  { 334, -1, sizeof(::dapr::proto::runtime::v1::TransactionalActorStateOperation)},
+  { 342, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorRequest)},
+  { 351, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorResponse)},
+  { 357, 364, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse)},
+  { 366, -1, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse)},
+  { 375, -1, sizeof(::dapr::proto::runtime::v1::ActiveActorsCount)},
+  { 382, -1, sizeof(::dapr::proto::runtime::v1::RegisteredComponents)},
+  { 390, -1, sizeof(::dapr::proto::runtime::v1::SetMetadataRequest)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -1260,6 +1501,7 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetStateResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteStateRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteBulkStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SaveStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_PublishEventRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_PublishEventRequest_default_instance_),
@@ -1273,6 +1515,8 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetSecretResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkSecretRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkSecretRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SecretResponse_SecretsEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SecretResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkSecretResponse_DataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetBulkSecretResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TransactionalStateOperation_default_instance_),
@@ -1288,6 +1532,11 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TransactionalActorStateOperation_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_InvokeActorRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_InvokeActorResponse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetMetadataResponse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_ActiveActorsCount_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_RegisteredComponents_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SetMetadataRequest_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -1305,7 +1554,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 40);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 48);
 }
 
 void AddDescriptorsImpl() {
@@ -1339,79 +1588,99 @@ void AddDescriptorsImpl() {
       "tag\030\002 \001(\t\022G\n\010metadata\030\003 \003(\01325.dapr.proto"
       ".runtime.v1.GetStateResponse.MetadataEnt"
       "ry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
-      "e\030\002 \001(\t:\0028\001\"\364\001\n\022DeleteStateRequest\022\022\n\nst"
-      "ore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022\014\n\004etag\030\003 \001("
-      "\t\0223\n\007options\030\004 \001(\0132\".dapr.proto.common.v"
-      "1.StateOptions\022I\n\010metadata\030\005 \003(\01327.dapr."
-      "proto.runtime.v1.DeleteStateRequest.Meta"
-      "dataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022"
-      "\r\n\005value\030\002 \001(\t:\0028\001\"W\n\020SaveStateRequest\022\022"
-      "\n\nstore_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037.dap"
-      "r.proto.common.v1.StateItem\"\337\001\n\023PublishE"
-      "ventRequest\022\023\n\013pubsub_name\030\001 \001(\t\022\r\n\005topi"
-      "c\030\002 \001(\t\022\014\n\004data\030\003 \001(\014\022\031\n\021data_content_ty"
-      "pe\030\004 \001(\t\022J\n\010metadata\030\005 \003(\01328.dapr.proto."
-      "runtime.v1.PublishEventRequest.MetadataE"
-      "ntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va"
-      "lue\030\002 \001(\t:\0028\001\"\303\001\n\024InvokeBindingRequest\022\014"
-      "\n\004name\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022K\n\010metadata\030\003"
-      " \003(\01329.dapr.proto.runtime.v1.InvokeBindi"
-      "ngRequest.MetadataEntry\022\021\n\toperation\030\004 \001"
-      "(\t\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
-      "e\030\002 \001(\t:\0028\001\"\244\001\n\025InvokeBindingResponse\022\014\n"
-      "\004data\030\001 \001(\014\022L\n\010metadata\030\002 \003(\0132:.dapr.pro"
-      "to.runtime.v1.InvokeBindingResponse.Meta"
-      "dataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022"
-      "\r\n\005value\030\002 \001(\t:\0028\001\"\255\001\n\020GetSecretRequest\022"
-      "\022\n\nstore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022G\n\010meta"
-      "data\030\003 \003(\01325.dapr.proto.runtime.v1.GetSe"
-      "cretRequest.MetadataEntry\032/\n\rMetadataEnt"
-      "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001\n\021G"
-      "etSecretResponse\022@\n\004data\030\001 \003(\01322.dapr.pr"
-      "oto.runtime.v1.GetSecretResponse.DataEnt"
-      "ry\032+\n\tDataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 "
-      "\001(\t:\0028\001\"\250\001\n\024GetBulkSecretRequest\022\022\n\nstor"
-      "e_name\030\001 \001(\t\022K\n\010metadata\030\002 \003(\01329.dapr.pr"
-      "oto.runtime.v1.GetBulkSecretRequest.Meta"
-      "dataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022"
-      "\r\n\005value\030\002 \001(\t:\0028\001\"\212\001\n\025GetBulkSecretResp"
-      "onse\022D\n\004data\030\001 \003(\01326.dapr.proto.runtime."
-      "v1.GetBulkSecretResponse.DataEntry\032+\n\tDa"
-      "taEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\""
-      "f\n\033TransactionalStateOperation\022\025\n\roperat"
-      "ionType\030\001 \001(\t\0220\n\007request\030\002 \001(\0132\037.dapr.pr"
-      "oto.common.v1.StateItem\"\203\002\n\036ExecuteState"
-      "TransactionRequest\022\021\n\tstoreName\030\001 \001(\t\022F\n"
-      "\noperations\030\002 \003(\01322.dapr.proto.runtime.v"
-      "1.TransactionalStateOperation\022U\n\010metadat"
-      "a\030\003 \003(\0132C.dapr.proto.runtime.v1.ExecuteS"
-      "tateTransactionRequest.MetadataEntry\032/\n\r"
-      "MetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001("
-      "\t:\0028\001\"\221\001\n\031RegisterActorTimerRequest\022\022\n\na"
-      "ctor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n\004nam"
-      "e\030\003 \001(\t\022\020\n\010due_time\030\004 \001(\t\022\016\n\006period\030\005 \001("
-      "\t\022\020\n\010callback\030\006 \001(\t\022\014\n\004data\030\007 \001(\014\"Q\n\033Unr"
-      "egisterActorTimerRequest\022\022\n\nactor_type\030\001"
-      " \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\"\202\001\n"
-      "\034RegisterActorReminderRequest\022\022\n\nactor_t"
-      "ype\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n\004name\030\003 \001("
-      "\t\022\020\n\010due_time\030\004 \001(\t\022\016\n\006period\030\005 \001(\t\022\014\n\004d"
-      "ata\030\006 \001(\014\"T\n\036UnregisterActorReminderRequ"
-      "est\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001("
-      "\t\022\014\n\004name\030\003 \001(\t\"I\n\024GetActorStateRequest\022"
-      "\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\013\n"
-      "\003key\030\003 \001(\t\"%\n\025GetActorStateResponse\022\014\n\004d"
-      "ata\030\001 \001(\014\"\230\001\n#ExecuteActorStateTransacti"
-      "onRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_i"
-      "d\030\002 \001(\t\022K\n\noperations\030\003 \003(\01327.dapr.proto"
-      ".runtime.v1.TransactionalActorStateOpera"
-      "tion\"k\n TransactionalActorStateOperation"
-      "\022\025\n\roperationType\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022#\n\005"
-      "value\030\003 \001(\0132\024.google.protobuf.Any\"X\n\022Inv"
-      "okeActorRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010a"
-      "ctor_id\030\002 \001(\t\022\016\n\006method\030\003 \001(\t\022\014\n\004data\030\004 "
-      "\001(\014\"#\n\023InvokeActorResponse\022\014\n\004data\030\001 \001(\014"
-      "2\302\r\n\004Dapr\022d\n\rInvokeService\022+.dapr.proto."
+      "e\030\002 \001(\t:\0028\001\"\220\002\n\022DeleteStateRequest\022\022\n\nst"
+      "ore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022(\n\004etag\030\003 \001("
+      "\0132\032.dapr.proto.common.v1.Etag\0223\n\007options"
+      "\030\004 \001(\0132\".dapr.proto.common.v1.StateOptio"
+      "ns\022I\n\010metadata\030\005 \003(\01327.dapr.proto.runtim"
+      "e.v1.DeleteStateRequest.MetadataEntry\032/\n"
+      "\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001"
+      "(\t:\0028\001\"]\n\026DeleteBulkStateRequest\022\022\n\nstor"
+      "e_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037.dapr.prot"
+      "o.common.v1.StateItem\"W\n\020SaveStateReques"
+      "t\022\022\n\nstore_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037."
+      "dapr.proto.common.v1.StateItem\"\337\001\n\023Publi"
+      "shEventRequest\022\023\n\013pubsub_name\030\001 \001(\t\022\r\n\005t"
+      "opic\030\002 \001(\t\022\014\n\004data\030\003 \001(\014\022\031\n\021data_content"
+      "_type\030\004 \001(\t\022J\n\010metadata\030\005 \003(\01328.dapr.pro"
+      "to.runtime.v1.PublishEventRequest.Metada"
+      "taEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
+      "\005value\030\002 \001(\t:\0028\001\"\303\001\n\024InvokeBindingReques"
+      "t\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022K\n\010metadat"
+      "a\030\003 \003(\01329.dapr.proto.runtime.v1.InvokeBi"
+      "ndingRequest.MetadataEntry\022\021\n\toperation\030"
+      "\004 \001(\t\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v"
+      "alue\030\002 \001(\t:\0028\001\"\244\001\n\025InvokeBindingResponse"
+      "\022\014\n\004data\030\001 \001(\014\022L\n\010metadata\030\002 \003(\0132:.dapr."
+      "proto.runtime.v1.InvokeBindingResponse.M"
+      "etadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001"
+      "(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\255\001\n\020GetSecretReque"
+      "st\022\022\n\nstore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022G\n\010m"
+      "etadata\030\003 \003(\01325.dapr.proto.runtime.v1.Ge"
+      "tSecretRequest.MetadataEntry\032/\n\rMetadata"
+      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001"
+      "\n\021GetSecretResponse\022@\n\004data\030\001 \003(\01322.dapr"
+      ".proto.runtime.v1.GetSecretResponse.Data"
+      "Entry\032+\n\tDataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+      "\030\002 \001(\t:\0028\001\"\250\001\n\024GetBulkSecretRequest\022\022\n\ns"
+      "tore_name\030\001 \001(\t\022K\n\010metadata\030\002 \003(\01329.dapr"
+      ".proto.runtime.v1.GetBulkSecretRequest.M"
+      "etadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001"
+      "(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\205\001\n\016SecretResponse"
+      "\022C\n\007secrets\030\001 \003(\01322.dapr.proto.runtime.v"
+      "1.SecretResponse.SecretsEntry\032.\n\014Secrets"
+      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\261\001"
+      "\n\025GetBulkSecretResponse\022D\n\004data\030\001 \003(\01326."
+      "dapr.proto.runtime.v1.GetBulkSecretRespo"
+      "nse.DataEntry\032R\n\tDataEntry\022\013\n\003key\030\001 \001(\t\022"
+      "4\n\005value\030\002 \001(\0132%.dapr.proto.runtime.v1.S"
+      "ecretResponse:\0028\001\"f\n\033TransactionalStateO"
+      "peration\022\025\n\roperationType\030\001 \001(\t\0220\n\007reque"
+      "st\030\002 \001(\0132\037.dapr.proto.common.v1.StateIte"
+      "m\"\203\002\n\036ExecuteStateTransactionRequest\022\021\n\t"
+      "storeName\030\001 \001(\t\022F\n\noperations\030\002 \003(\01322.da"
+      "pr.proto.runtime.v1.TransactionalStateOp"
+      "eration\022U\n\010metadata\030\003 \003(\0132C.dapr.proto.r"
+      "untime.v1.ExecuteStateTransactionRequest"
+      ".MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001"
+      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\221\001\n\031RegisterActo"
+      "rTimerRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010act"
+      "or_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 "
+      "\001(\t\022\016\n\006period\030\005 \001(\t\022\020\n\010callback\030\006 \001(\t\022\014\n"
+      "\004data\030\007 \001(\014\"Q\n\033UnregisterActorTimerReque"
+      "st\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t"
+      "\022\014\n\004name\030\003 \001(\t\"\202\001\n\034RegisterActorReminder"
+      "Request\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030"
+      "\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 \001(\t\022\016\n"
+      "\006period\030\005 \001(\t\022\014\n\004data\030\006 \001(\014\"T\n\036Unregiste"
+      "rActorReminderRequest\022\022\n\nactor_type\030\001 \001("
+      "\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\"I\n\024Get"
+      "ActorStateRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n"
+      "\010actor_id\030\002 \001(\t\022\013\n\003key\030\003 \001(\t\"%\n\025GetActor"
+      "StateResponse\022\014\n\004data\030\001 \001(\014\"\230\001\n#ExecuteA"
+      "ctorStateTransactionRequest\022\022\n\nactor_typ"
+      "e\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022K\n\noperations\030"
+      "\003 \003(\01327.dapr.proto.runtime.v1.Transactio"
+      "nalActorStateOperation\"k\n TransactionalA"
+      "ctorStateOperation\022\025\n\roperationType\030\001 \001("
+      "\t\022\013\n\003key\030\002 \001(\t\022#\n\005value\030\003 \001(\0132\024.google.p"
+      "rotobuf.Any\"X\n\022InvokeActorRequest\022\022\n\nact"
+      "or_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\016\n\006metho"
+      "d\030\003 \001(\t\022\014\n\004data\030\004 \001(\014\"#\n\023InvokeActorResp"
+      "onse\022\014\n\004data\030\001 \001(\014\"\312\002\n\023GetMetadataRespon"
+      "se\022\n\n\002id\030\001 \001(\t\022E\n\023active_actors_count\030\002 "
+      "\003(\0132(.dapr.proto.runtime.v1.ActiveActors"
+      "Count\022J\n\025registered_components\030\003 \003(\0132+.d"
+      "apr.proto.runtime.v1.RegisteredComponent"
+      "s\022[\n\021extended_metadata\030\004 \003(\0132@.dapr.prot"
+      "o.runtime.v1.GetMetadataResponse.Extende"
+      "dMetadataEntry\0327\n\025ExtendedMetadataEntry\022"
+      "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"0\n\021Activ"
+      "eActorsCount\022\014\n\004type\030\001 \001(\t\022\r\n\005count\030\002 \001("
+      "\005\"C\n\024RegisteredComponents\022\014\n\004name\030\001 \001(\t\022"
+      "\014\n\004type\030\002 \001(\t\022\017\n\007version\030\003 \001(\t\"0\n\022SetMet"
+      "adataRequest\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t"
+      "2\307\017\n\004Dapr\022d\n\rInvokeService\022+.dapr.proto."
       "runtime.v1.InvokeServiceRequest\032$.dapr.p"
       "roto.common.v1.InvokeResponse\"\000\022]\n\010GetSt"
       "ate\022&.dapr.proto.runtime.v1.GetStateRequ"
@@ -1422,45 +1691,51 @@ void AddDescriptorsImpl() {
       "eState\022\'.dapr.proto.runtime.v1.SaveState"
       "Request\032\026.google.protobuf.Empty\"\000\022R\n\013Del"
       "eteState\022).dapr.proto.runtime.v1.DeleteS"
-      "tateRequest\032\026.google.protobuf.Empty\"\000\022j\n"
-      "\027ExecuteStateTransaction\0225.dapr.proto.ru"
-      "ntime.v1.ExecuteStateTransactionRequest\032"
-      "\026.google.protobuf.Empty\"\000\022T\n\014PublishEven"
-      "t\022*.dapr.proto.runtime.v1.PublishEventRe"
-      "quest\032\026.google.protobuf.Empty\"\000\022l\n\rInvok"
-      "eBinding\022+.dapr.proto.runtime.v1.InvokeB"
-      "indingRequest\032,.dapr.proto.runtime.v1.In"
-      "vokeBindingResponse\"\000\022`\n\tGetSecret\022\'.dap"
-      "r.proto.runtime.v1.GetSecretRequest\032(.da"
-      "pr.proto.runtime.v1.GetSecretResponse\"\000\022"
-      "l\n\rGetBulkSecret\022+.dapr.proto.runtime.v1"
-      ".GetBulkSecretRequest\032,.dapr.proto.runti"
-      "me.v1.GetBulkSecretResponse\"\000\022`\n\022Registe"
-      "rActorTimer\0220.dapr.proto.runtime.v1.Regi"
-      "sterActorTimerRequest\032\026.google.protobuf."
-      "Empty\"\000\022d\n\024UnregisterActorTimer\0222.dapr.p"
-      "roto.runtime.v1.UnregisterActorTimerRequ"
-      "est\032\026.google.protobuf.Empty\"\000\022f\n\025Registe"
-      "rActorReminder\0223.dapr.proto.runtime.v1.R"
+      "tateRequest\032\026.google.protobuf.Empty\"\000\022Z\n"
+      "\017DeleteBulkState\022-.dapr.proto.runtime.v1"
+      ".DeleteBulkStateRequest\032\026.google.protobu"
+      "f.Empty\"\000\022j\n\027ExecuteStateTransaction\0225.d"
+      "apr.proto.runtime.v1.ExecuteStateTransac"
+      "tionRequest\032\026.google.protobuf.Empty\"\000\022T\n"
+      "\014PublishEvent\022*.dapr.proto.runtime.v1.Pu"
+      "blishEventRequest\032\026.google.protobuf.Empt"
+      "y\"\000\022l\n\rInvokeBinding\022+.dapr.proto.runtim"
+      "e.v1.InvokeBindingRequest\032,.dapr.proto.r"
+      "untime.v1.InvokeBindingResponse\"\000\022`\n\tGet"
+      "Secret\022\'.dapr.proto.runtime.v1.GetSecret"
+      "Request\032(.dapr.proto.runtime.v1.GetSecre"
+      "tResponse\"\000\022l\n\rGetBulkSecret\022+.dapr.prot"
+      "o.runtime.v1.GetBulkSecretRequest\032,.dapr"
+      ".proto.runtime.v1.GetBulkSecretResponse\""
+      "\000\022`\n\022RegisterActorTimer\0220.dapr.proto.run"
+      "time.v1.RegisterActorTimerRequest\032\026.goog"
+      "le.protobuf.Empty\"\000\022d\n\024UnregisterActorTi"
+      "mer\0222.dapr.proto.runtime.v1.UnregisterAc"
+      "torTimerRequest\032\026.google.protobuf.Empty\""
+      "\000\022f\n\025RegisterActorReminder\0223.dapr.proto."
+      "runtime.v1.RegisterActorReminderRequest\032"
+      "\026.google.protobuf.Empty\"\000\022j\n\027UnregisterA"
+      "ctorReminder\0225.dapr.proto.runtime.v1.Unr"
       "egisterActorReminderRequest\032\026.google.pro"
-      "tobuf.Empty\"\000\022j\n\027UnregisterActorReminder"
-      "\0225.dapr.proto.runtime.v1.UnregisterActor"
-      "ReminderRequest\032\026.google.protobuf.Empty\""
-      "\000\022l\n\rGetActorState\022+.dapr.proto.runtime."
-      "v1.GetActorStateRequest\032,.dapr.proto.run"
-      "time.v1.GetActorStateResponse\"\000\022t\n\034Execu"
-      "teActorStateTransaction\022:.dapr.proto.run"
-      "time.v1.ExecuteActorStateTransactionRequ"
-      "est\032\026.google.protobuf.Empty\"\000\022f\n\013InvokeA"
-      "ctor\022).dapr.proto.runtime.v1.InvokeActor"
-      "Request\032*.dapr.proto.runtime.v1.InvokeAc"
-      "torResponse\"\000Bi\n\nio.dapr.v1B\nDaprProtosZ"
-      "1github.com/dapr/dapr/pkg/proto/runtime/"
-      "v1;runtime\252\002\033Dapr.Client.Autogen.Grpc.v1"
-      "b\006proto3"
+      "tobuf.Empty\"\000\022l\n\rGetActorState\022+.dapr.pr"
+      "oto.runtime.v1.GetActorStateRequest\032,.da"
+      "pr.proto.runtime.v1.GetActorStateRespons"
+      "e\"\000\022t\n\034ExecuteActorStateTransaction\022:.da"
+      "pr.proto.runtime.v1.ExecuteActorStateTra"
+      "nsactionRequest\032\026.google.protobuf.Empty\""
+      "\000\022f\n\013InvokeActor\022).dapr.proto.runtime.v1"
+      ".InvokeActorRequest\032*.dapr.proto.runtime"
+      ".v1.InvokeActorResponse\"\000\022S\n\013GetMetadata"
+      "\022\026.google.protobuf.Empty\032*.dapr.proto.ru"
+      "ntime.v1.GetMetadataResponse\"\000\022R\n\013SetMet"
+      "adata\022).dapr.proto.runtime.v1.SetMetadat"
+      "aRequest\032\026.google.protobuf.Empty\"\000Bi\n\nio"
+      ".dapr.v1B\nDaprProtosZ1github.com/dapr/da"
+      "pr/pkg/proto/runtime/v1;runtime\252\002\033Dapr.C"
+      "lient.Autogen.Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 5848);
+      descriptor, 6909);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/dapr.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();
@@ -4087,8 +4362,16 @@ void DeleteStateRequest_MetadataEntry_DoNotUse::MergeFrom(
 // ===================================================================
 
 void DeleteStateRequest::InitAsDefaultInstance() {
+  ::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_._instance.get_mutable()->etag_ = const_cast< ::dapr::proto::common::v1::Etag*>(
+      ::dapr::proto::common::v1::Etag::internal_default_instance());
   ::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_._instance.get_mutable()->options_ = const_cast< ::dapr::proto::common::v1::StateOptions*>(
       ::dapr::proto::common::v1::StateOptions::internal_default_instance());
+}
+void DeleteStateRequest::clear_etag() {
+  if (GetArenaNoVirtual() == NULL && etag_ != NULL) {
+    delete etag_;
+  }
+  etag_ = NULL;
 }
 void DeleteStateRequest::clear_options() {
   if (GetArenaNoVirtual() == NULL && options_ != NULL) {
@@ -4124,9 +4407,10 @@ DeleteStateRequest::DeleteStateRequest(const DeleteStateRequest& from)
   if (from.key().size() > 0) {
     key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
   }
-  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.etag().size() > 0) {
-    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  if (from.has_etag()) {
+    etag_ = new ::dapr::proto::common::v1::Etag(*from.etag_);
+  } else {
+    etag_ = NULL;
   }
   if (from.has_options()) {
     options_ = new ::dapr::proto::common::v1::StateOptions(*from.options_);
@@ -4139,8 +4423,9 @@ DeleteStateRequest::DeleteStateRequest(const DeleteStateRequest& from)
 void DeleteStateRequest::SharedCtor() {
   store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  ::memset(&etag_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&options_) -
+      reinterpret_cast<char*>(&etag_)) + sizeof(options_));
 }
 
 DeleteStateRequest::~DeleteStateRequest() {
@@ -4151,7 +4436,7 @@ DeleteStateRequest::~DeleteStateRequest() {
 void DeleteStateRequest::SharedDtor() {
   store_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete etag_;
   if (this != internal_default_instance()) delete options_;
 }
 
@@ -4178,7 +4463,10 @@ void DeleteStateRequest::Clear() {
   metadata_.Clear();
   store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (GetArenaNoVirtual() == NULL && etag_ != NULL) {
+    delete etag_;
+  }
+  etag_ = NULL;
   if (GetArenaNoVirtual() == NULL && options_ != NULL) {
     delete options_;
   }
@@ -4228,16 +4516,12 @@ bool DeleteStateRequest::MergePartialFromCodedStream(
         break;
       }
 
-      // string etag = 3;
+      // .dapr.proto.common.v1.Etag etag = 3;
       case 3: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
-                input, this->mutable_etag()));
-          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-            this->etag().data(), static_cast<int>(this->etag().length()),
-            ::google::protobuf::internal::WireFormatLite::PARSE,
-            "dapr.proto.runtime.v1.DeleteStateRequest.etag"));
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_etag()));
         } else {
           goto handle_unusual;
         }
@@ -4329,14 +4613,10 @@ void DeleteStateRequest::SerializeWithCachedSizes(
       2, this->key(), output);
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->etag().data(), static_cast<int>(this->etag().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "dapr.proto.runtime.v1.DeleteStateRequest.etag");
-    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
-      3, this->etag(), output);
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->_internal_etag(), output);
   }
 
   // .dapr.proto.common.v1.StateOptions options = 4;
@@ -4434,15 +4714,11 @@ void DeleteStateRequest::SerializeWithCachedSizes(
         2, this->key(), target);
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->etag().data(), static_cast<int>(this->etag().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "dapr.proto.runtime.v1.DeleteStateRequest.etag");
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
-        3, this->etag(), target);
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        3, this->_internal_etag(), deterministic, target);
   }
 
   // .dapr.proto.common.v1.StateOptions options = 4;
@@ -4554,11 +4830,11 @@ size_t DeleteStateRequest::ByteSizeLong() const {
         this->key());
   }
 
-  // string etag = 3;
-  if (this->etag().size() > 0) {
+  // .dapr.proto.common.v1.Etag etag = 3;
+  if (this->has_etag()) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::StringSize(
-        this->etag());
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *etag_);
   }
 
   // .dapr.proto.common.v1.StateOptions options = 4;
@@ -4604,9 +4880,8 @@ void DeleteStateRequest::MergeFrom(const DeleteStateRequest& from) {
 
     key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
   }
-  if (from.etag().size() > 0) {
-
-    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  if (from.has_etag()) {
+    mutable_etag()->::dapr::proto::common::v1::Etag::MergeFrom(from.etag());
   }
   if (from.has_options()) {
     mutable_options()->::dapr::proto::common::v1::StateOptions::MergeFrom(from.options());
@@ -4642,13 +4917,302 @@ void DeleteStateRequest::InternalSwap(DeleteStateRequest* other) {
     GetArenaNoVirtual());
   key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
-  etag_.Swap(&other->etag_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
+  swap(etag_, other->etag_);
   swap(options_, other->options_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
 ::google::protobuf::Metadata DeleteStateRequest::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void DeleteBulkStateRequest::InitAsDefaultInstance() {
+}
+void DeleteBulkStateRequest::clear_states() {
+  states_.Clear();
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int DeleteBulkStateRequest::kStoreNameFieldNumber;
+const int DeleteBulkStateRequest::kStatesFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+DeleteBulkStateRequest::DeleteBulkStateRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_DeleteBulkStateRequest.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+}
+DeleteBulkStateRequest::DeleteBulkStateRequest(const DeleteBulkStateRequest& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      states_(from.states_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.store_name().size() > 0) {
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+}
+
+void DeleteBulkStateRequest::SharedCtor() {
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+DeleteBulkStateRequest::~DeleteBulkStateRequest() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  SharedDtor();
+}
+
+void DeleteBulkStateRequest::SharedDtor() {
+  store_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void DeleteBulkStateRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* DeleteBulkStateRequest::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const DeleteBulkStateRequest& DeleteBulkStateRequest::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_DeleteBulkStateRequest.base);
+  return *internal_default_instance();
+}
+
+
+void DeleteBulkStateRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  states_.Clear();
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool DeleteBulkStateRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string store_name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_store_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->store_name().data(), static_cast<int>(this->store_name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated .dapr.proto.common.v1.StateItem states = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_states()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  return false;
+#undef DO_
+}
+
+void DeleteBulkStateRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->store_name(), output);
+  }
+
+  // repeated .dapr.proto.common.v1.StateItem states = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->states_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2,
+      this->states(static_cast<int>(i)),
+      output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+}
+
+::google::protobuf::uint8* DeleteBulkStateRequest::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->store_name(), target);
+  }
+
+  // repeated .dapr.proto.common.v1.StateItem states = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->states_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        2, this->states(static_cast<int>(i)), deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  return target;
+}
+
+size_t DeleteBulkStateRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.common.v1.StateItem states = 2;
+  {
+    unsigned int count = static_cast<unsigned int>(this->states_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->states(static_cast<int>(i)));
+    }
+  }
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->store_name());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void DeleteBulkStateRequest::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const DeleteBulkStateRequest* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const DeleteBulkStateRequest>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+    MergeFrom(*source);
+  }
+}
+
+void DeleteBulkStateRequest::MergeFrom(const DeleteBulkStateRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  states_.MergeFrom(from.states_);
+  if (from.store_name().size() > 0) {
+
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+}
+
+void DeleteBulkStateRequest::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void DeleteBulkStateRequest::CopyFrom(const DeleteBulkStateRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DeleteBulkStateRequest::IsInitialized() const {
+  return true;
+}
+
+void DeleteBulkStateRequest::Swap(DeleteBulkStateRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void DeleteBulkStateRequest::InternalSwap(DeleteBulkStateRequest* other) {
+  using std::swap;
+  CastToBase(&states_)->InternalSwap(CastToBase(&other->states_));
+  store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata DeleteBulkStateRequest::GetMetadata() const {
   protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -4953,7 +5517,7 @@ void PublishEventRequest_MetadataEntry_DoNotUse::MergeFrom(const PublishEventReq
 }
 ::google::protobuf::Metadata PublishEventRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[13];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[14];
 }
 void PublishEventRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -5530,7 +6094,7 @@ void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(const InvokeBindingR
 }
 ::google::protobuf::Metadata InvokeBindingRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[15];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[16];
 }
 void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6049,7 +6613,7 @@ void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(const InvokeBinding
 }
 ::google::protobuf::Metadata InvokeBindingResponse_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[17];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[18];
 }
 void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6452,7 +7016,7 @@ void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(const GetSecretRequest_M
 }
 ::google::protobuf::Metadata GetSecretRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[19];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[20];
 }
 void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6925,7 +7489,7 @@ void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetSecretResponse_Dat
 }
 ::google::protobuf::Metadata GetSecretResponse_DataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[21];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[22];
 }
 void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7282,7 +7846,7 @@ void GetBulkSecretRequest_MetadataEntry_DoNotUse::MergeFrom(const GetBulkSecretR
 }
 ::google::protobuf::Metadata GetBulkSecretRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[23];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[24];
 }
 void GetBulkSecretRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7690,6 +8254,363 @@ void GetBulkSecretRequest::InternalSwap(GetBulkSecretRequest* other) {
 
 // ===================================================================
 
+SecretResponse_SecretsEntry_DoNotUse::SecretResponse_SecretsEntry_DoNotUse() {}
+SecretResponse_SecretsEntry_DoNotUse::SecretResponse_SecretsEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void SecretResponse_SecretsEntry_DoNotUse::MergeFrom(const SecretResponse_SecretsEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata SecretResponse_SecretsEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[26];
+}
+void SecretResponse_SecretsEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void SecretResponse::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int SecretResponse::kSecretsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+SecretResponse::SecretResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SecretResponse.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.SecretResponse)
+}
+SecretResponse::SecretResponse(const SecretResponse& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  secrets_.MergeFrom(from.secrets_);
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.SecretResponse)
+}
+
+void SecretResponse::SharedCtor() {
+}
+
+SecretResponse::~SecretResponse() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.SecretResponse)
+  SharedDtor();
+}
+
+void SecretResponse::SharedDtor() {
+}
+
+void SecretResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* SecretResponse::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const SecretResponse& SecretResponse::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SecretResponse.base);
+  return *internal_default_instance();
+}
+
+
+void SecretResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.SecretResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  secrets_.Clear();
+  _internal_metadata_.Clear();
+}
+
+bool SecretResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.SecretResponse)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // map<string, string> secrets = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          SecretResponse_SecretsEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              SecretResponse_SecretsEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&secrets_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.SecretResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.SecretResponse)
+  return false;
+#undef DO_
+}
+
+void SecretResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.SecretResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // map<string, string> secrets = 1;
+  if (!this->secrets().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->secrets().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->secrets().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->secrets().begin();
+          it != this->secrets().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<SecretResponse_SecretsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(secrets_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            1, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<SecretResponse_SecretsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->secrets().begin();
+          it != this->secrets().end(); ++it) {
+        entry.reset(secrets_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            1, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.SecretResponse)
+}
+
+::google::protobuf::uint8* SecretResponse::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.SecretResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // map<string, string> secrets = 1;
+  if (!this->secrets().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SecretResponse.SecretsEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->secrets().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->secrets().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->secrets().begin();
+          it != this->secrets().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<SecretResponse_SecretsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(secrets_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       1, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<SecretResponse_SecretsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->secrets().begin();
+          it != this->secrets().end(); ++it) {
+        entry.reset(secrets_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       1, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.SecretResponse)
+  return target;
+}
+
+size_t SecretResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.SecretResponse)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // map<string, string> secrets = 1;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->secrets_size());
+  {
+    ::std::unique_ptr<SecretResponse_SecretsEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->secrets().begin();
+        it != this->secrets().end(); ++it) {
+      entry.reset(secrets_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SecretResponse::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.SecretResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SecretResponse* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const SecretResponse>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.SecretResponse)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.SecretResponse)
+    MergeFrom(*source);
+  }
+}
+
+void SecretResponse::MergeFrom(const SecretResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.SecretResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  secrets_.MergeFrom(from.secrets_);
+}
+
+void SecretResponse::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.SecretResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SecretResponse::CopyFrom(const SecretResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.SecretResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SecretResponse::IsInitialized() const {
+  return true;
+}
+
+void SecretResponse::Swap(SecretResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SecretResponse::InternalSwap(SecretResponse* other) {
+  using std::swap;
+  secrets_.Swap(&other->secrets_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata SecretResponse::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
 GetBulkSecretResponse_DataEntry_DoNotUse::GetBulkSecretResponse_DataEntry_DoNotUse() {}
 GetBulkSecretResponse_DataEntry_DoNotUse::GetBulkSecretResponse_DataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
 void GetBulkSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetBulkSecretResponse_DataEntry_DoNotUse& other) {
@@ -7697,7 +8618,7 @@ void GetBulkSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetBulkSecretResp
 }
 ::google::protobuf::Metadata GetBulkSecretResponse_DataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[25];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[28];
 }
 void GetBulkSecretResponse_DataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7773,27 +8694,23 @@ bool GetBulkSecretResponse::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // map<string, string> data = 1;
+      // map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
           GetBulkSecretResponse_DataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
               GetBulkSecretResponse_DataEntry_DoNotUse,
-              ::std::string, ::std::string,
+              ::std::string, ::dapr::proto::runtime::v1::SecretResponse,
               ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
-              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
               0 >,
-            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&data_);
+            ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse > > parser(&data_);
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
               input, &parser));
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             parser.key().data(), static_cast<int>(parser.key().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
             "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.key"));
-          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-            parser.value().data(), static_cast<int>(parser.value().length()),
-            ::google::protobuf::internal::WireFormatLite::PARSE,
-            "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.value"));
         } else {
           goto handle_unusual;
         }
@@ -7826,9 +8743,9 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // map<string, string> data = 1;
+  // map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
   if (!this->data().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -7838,10 +8755,6 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
           "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.key");
-        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-          p->second.data(), static_cast<int>(p->second.length()),
-          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.value");
       }
     };
 
@@ -7849,9 +8762,9 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
         this->data().size() > 1) {
       ::std::unique_ptr<SortItem[]> items(
           new SortItem[this->data().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_iterator
           it = this->data().begin();
           it != this->data().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -7867,7 +8780,7 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
       }
     } else {
       ::std::unique_ptr<GetBulkSecretResponse_DataEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_iterator
           it = this->data().begin();
           it != this->data().end(); ++it) {
         entry.reset(data_.NewEntryWrapper(
@@ -7893,9 +8806,9 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // map<string, string> data = 1;
+  // map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
   if (!this->data().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -7905,10 +8818,6 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
           "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.key");
-        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-          p->second.data(), static_cast<int>(p->second.length()),
-          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "dapr.proto.runtime.v1.GetBulkSecretResponse.DataEntry.value");
       }
     };
 
@@ -7916,9 +8825,9 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
         this->data().size() > 1) {
       ::std::unique_ptr<SortItem[]> items(
           new SortItem[this->data().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_iterator
           it = this->data().begin();
           it != this->data().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -7936,7 +8845,7 @@ void GetBulkSecretResponse::SerializeWithCachedSizes(
       }
     } else {
       ::std::unique_ptr<GetBulkSecretResponse_DataEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_iterator
           it = this->data().begin();
           it != this->data().end(); ++it) {
         entry.reset(data_.NewEntryWrapper(
@@ -7967,12 +8876,12 @@ size_t GetBulkSecretResponse::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // map<string, string> data = 1;
+  // map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
   total_size += 1 *
       ::google::protobuf::internal::FromIntSize(this->data_size());
   {
     ::std::unique_ptr<GetBulkSecretResponse_DataEntry_DoNotUse> entry;
-    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+    for (::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >::const_iterator
         it = this->data().begin();
         it != this->data().end(); ++it) {
       entry.reset(data_.NewEntryWrapper(it->first, it->second));
@@ -8352,7 +9261,7 @@ void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(const Exec
 }
 ::google::protobuf::Metadata ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[28];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[31];
 }
 void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -12540,6 +13449,1450 @@ void InvokeActorResponse::InternalSwap(InvokeActorResponse* other) {
 }
 
 
+// ===================================================================
+
+GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse() {}
+GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::MergeFrom(const GetMetadataResponse_ExtendedMetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[43];
+}
+void GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void GetMetadataResponse::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GetMetadataResponse::kIdFieldNumber;
+const int GetMetadataResponse::kActiveActorsCountFieldNumber;
+const int GetMetadataResponse::kRegisteredComponentsFieldNumber;
+const int GetMetadataResponse::kExtendedMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GetMetadataResponse::GetMetadataResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetMetadataResponse.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.GetMetadataResponse)
+}
+GetMetadataResponse::GetMetadataResponse(const GetMetadataResponse& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      active_actors_count_(from.active_actors_count_),
+      registered_components_(from.registered_components_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  extended_metadata_.MergeFrom(from.extended_metadata_);
+  id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.id().size() > 0) {
+    id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.id_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.GetMetadataResponse)
+}
+
+void GetMetadataResponse::SharedCtor() {
+  id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+GetMetadataResponse::~GetMetadataResponse() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.GetMetadataResponse)
+  SharedDtor();
+}
+
+void GetMetadataResponse::SharedDtor() {
+  id_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void GetMetadataResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* GetMetadataResponse::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GetMetadataResponse& GetMetadataResponse::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetMetadataResponse.base);
+  return *internal_default_instance();
+}
+
+
+void GetMetadataResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  active_actors_count_.Clear();
+  registered_components_.Clear();
+  extended_metadata_.Clear();
+  id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool GetMetadataResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string id = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_id()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->id().data(), static_cast<int>(this->id().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetMetadataResponse.id"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_active_actors_count()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_registered_components()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> extended_metadata = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GetMetadataResponse_ExtendedMetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&extended_metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.GetMetadataResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.GetMetadataResponse)
+  return false;
+#undef DO_
+}
+
+void GetMetadataResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string id = 1;
+  if (this->id().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->id().data(), static_cast<int>(this->id().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetMetadataResponse.id");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->id(), output);
+  }
+
+  // repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->active_actors_count_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2,
+      this->active_actors_count(static_cast<int>(i)),
+      output);
+  }
+
+  // repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->registered_components_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3,
+      this->registered_components(static_cast<int>(i)),
+      output);
+  }
+
+  // map<string, string> extended_metadata = 4;
+  if (!this->extended_metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->extended_metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->extended_metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->extended_metadata().begin();
+          it != this->extended_metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(extended_metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->extended_metadata().begin();
+          it != this->extended_metadata().end(); ++it) {
+        entry.reset(extended_metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.GetMetadataResponse)
+}
+
+::google::protobuf::uint8* GetMetadataResponse::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string id = 1;
+  if (this->id().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->id().data(), static_cast<int>(this->id().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetMetadataResponse.id");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->id(), target);
+  }
+
+  // repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->active_actors_count_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        2, this->active_actors_count(static_cast<int>(i)), deterministic, target);
+  }
+
+  // repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->registered_components_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        3, this->registered_components(static_cast<int>(i)), deterministic, target);
+  }
+
+  // map<string, string> extended_metadata = 4;
+  if (!this->extended_metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetMetadataResponse.ExtendedMetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->extended_metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->extended_metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->extended_metadata().begin();
+          it != this->extended_metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(extended_metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->extended_metadata().begin();
+          it != this->extended_metadata().end(); ++it) {
+        entry.reset(extended_metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.GetMetadataResponse)
+  return target;
+}
+
+size_t GetMetadataResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+  {
+    unsigned int count = static_cast<unsigned int>(this->active_actors_count_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->active_actors_count(static_cast<int>(i)));
+    }
+  }
+
+  // repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+  {
+    unsigned int count = static_cast<unsigned int>(this->registered_components_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->registered_components(static_cast<int>(i)));
+    }
+  }
+
+  // map<string, string> extended_metadata = 4;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->extended_metadata_size());
+  {
+    ::std::unique_ptr<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->extended_metadata().begin();
+        it != this->extended_metadata().end(); ++it) {
+      entry.reset(extended_metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string id = 1;
+  if (this->id().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->id());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GetMetadataResponse::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GetMetadataResponse* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GetMetadataResponse>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.GetMetadataResponse)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.GetMetadataResponse)
+    MergeFrom(*source);
+  }
+}
+
+void GetMetadataResponse::MergeFrom(const GetMetadataResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  active_actors_count_.MergeFrom(from.active_actors_count_);
+  registered_components_.MergeFrom(from.registered_components_);
+  extended_metadata_.MergeFrom(from.extended_metadata_);
+  if (from.id().size() > 0) {
+
+    id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.id_);
+  }
+}
+
+void GetMetadataResponse::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetMetadataResponse::CopyFrom(const GetMetadataResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.GetMetadataResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetMetadataResponse::IsInitialized() const {
+  return true;
+}
+
+void GetMetadataResponse::Swap(GetMetadataResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GetMetadataResponse::InternalSwap(GetMetadataResponse* other) {
+  using std::swap;
+  CastToBase(&active_actors_count_)->InternalSwap(CastToBase(&other->active_actors_count_));
+  CastToBase(&registered_components_)->InternalSwap(CastToBase(&other->registered_components_));
+  extended_metadata_.Swap(&other->extended_metadata_);
+  id_.Swap(&other->id_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata GetMetadataResponse::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ActiveActorsCount::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ActiveActorsCount::kTypeFieldNumber;
+const int ActiveActorsCount::kCountFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ActiveActorsCount::ActiveActorsCount()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_ActiveActorsCount.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.ActiveActorsCount)
+}
+ActiveActorsCount::ActiveActorsCount(const ActiveActorsCount& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  type_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.type().size() > 0) {
+    type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_);
+  }
+  count_ = from.count_;
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.ActiveActorsCount)
+}
+
+void ActiveActorsCount::SharedCtor() {
+  type_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  count_ = 0;
+}
+
+ActiveActorsCount::~ActiveActorsCount() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.ActiveActorsCount)
+  SharedDtor();
+}
+
+void ActiveActorsCount::SharedDtor() {
+  type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ActiveActorsCount::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ActiveActorsCount::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ActiveActorsCount& ActiveActorsCount::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_ActiveActorsCount.base);
+  return *internal_default_instance();
+}
+
+
+void ActiveActorsCount::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  type_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  count_ = 0;
+  _internal_metadata_.Clear();
+}
+
+bool ActiveActorsCount::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string type = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_type()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->type().data(), static_cast<int>(this->type().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.ActiveActorsCount.type"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int32 count = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(16u /* 16 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &count_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.ActiveActorsCount)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.ActiveActorsCount)
+  return false;
+#undef DO_
+}
+
+void ActiveActorsCount::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string type = 1;
+  if (this->type().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->type().data(), static_cast<int>(this->type().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.ActiveActorsCount.type");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->type(), output);
+  }
+
+  // int32 count = 2;
+  if (this->count() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->count(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.ActiveActorsCount)
+}
+
+::google::protobuf::uint8* ActiveActorsCount::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string type = 1;
+  if (this->type().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->type().data(), static_cast<int>(this->type().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.ActiveActorsCount.type");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->type(), target);
+  }
+
+  // int32 count = 2;
+  if (this->count() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->count(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.ActiveActorsCount)
+  return target;
+}
+
+size_t ActiveActorsCount::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string type = 1;
+  if (this->type().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->type());
+  }
+
+  // int32 count = 2;
+  if (this->count() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->count());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ActiveActorsCount::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ActiveActorsCount* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ActiveActorsCount>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.ActiveActorsCount)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.ActiveActorsCount)
+    MergeFrom(*source);
+  }
+}
+
+void ActiveActorsCount::MergeFrom(const ActiveActorsCount& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.type().size() > 0) {
+
+    type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_);
+  }
+  if (from.count() != 0) {
+    set_count(from.count());
+  }
+}
+
+void ActiveActorsCount::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ActiveActorsCount::CopyFrom(const ActiveActorsCount& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.ActiveActorsCount)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ActiveActorsCount::IsInitialized() const {
+  return true;
+}
+
+void ActiveActorsCount::Swap(ActiveActorsCount* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ActiveActorsCount::InternalSwap(ActiveActorsCount* other) {
+  using std::swap;
+  type_.Swap(&other->type_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  swap(count_, other->count_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ActiveActorsCount::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void RegisteredComponents::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int RegisteredComponents::kNameFieldNumber;
+const int RegisteredComponents::kTypeFieldNumber;
+const int RegisteredComponents::kVersionFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+RegisteredComponents::RegisteredComponents()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_RegisteredComponents.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.RegisteredComponents)
+}
+RegisteredComponents::RegisteredComponents(const RegisteredComponents& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.name().size() > 0) {
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  type_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.type().size() > 0) {
+    type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_);
+  }
+  version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.version().size() > 0) {
+    version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.version_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.RegisteredComponents)
+}
+
+void RegisteredComponents::SharedCtor() {
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  type_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+RegisteredComponents::~RegisteredComponents() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.RegisteredComponents)
+  SharedDtor();
+}
+
+void RegisteredComponents::SharedDtor() {
+  name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void RegisteredComponents::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* RegisteredComponents::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const RegisteredComponents& RegisteredComponents::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_RegisteredComponents.base);
+  return *internal_default_instance();
+}
+
+
+void RegisteredComponents::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.RegisteredComponents)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  type_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool RegisteredComponents::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.RegisteredComponents)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->name().data(), static_cast<int>(this->name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.RegisteredComponents.name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string type = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_type()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->type().data(), static_cast<int>(this->type().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.RegisteredComponents.type"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string version = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_version()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->version().data(), static_cast<int>(this->version().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.RegisteredComponents.version"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.RegisteredComponents)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.RegisteredComponents)
+  return false;
+#undef DO_
+}
+
+void RegisteredComponents::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.RegisteredComponents)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->name(), output);
+  }
+
+  // string type = 2;
+  if (this->type().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->type().data(), static_cast<int>(this->type().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.type");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->type(), output);
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->version().data(), static_cast<int>(this->version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.version");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      3, this->version(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.RegisteredComponents)
+}
+
+::google::protobuf::uint8* RegisteredComponents::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.RegisteredComponents)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->name(), target);
+  }
+
+  // string type = 2;
+  if (this->type().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->type().data(), static_cast<int>(this->type().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.type");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->type(), target);
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->version().data(), static_cast<int>(this->version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisteredComponents.version");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        3, this->version(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.RegisteredComponents)
+  return target;
+}
+
+size_t RegisteredComponents::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.RegisteredComponents)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string name = 1;
+  if (this->name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->name());
+  }
+
+  // string type = 2;
+  if (this->type().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->type());
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->version());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RegisteredComponents::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.RegisteredComponents)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RegisteredComponents* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const RegisteredComponents>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.RegisteredComponents)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.RegisteredComponents)
+    MergeFrom(*source);
+  }
+}
+
+void RegisteredComponents::MergeFrom(const RegisteredComponents& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.RegisteredComponents)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.name().size() > 0) {
+
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  if (from.type().size() > 0) {
+
+    type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_);
+  }
+  if (from.version().size() > 0) {
+
+    version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.version_);
+  }
+}
+
+void RegisteredComponents::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.RegisteredComponents)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RegisteredComponents::CopyFrom(const RegisteredComponents& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.RegisteredComponents)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RegisteredComponents::IsInitialized() const {
+  return true;
+}
+
+void RegisteredComponents::Swap(RegisteredComponents* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void RegisteredComponents::InternalSwap(RegisteredComponents* other) {
+  using std::swap;
+  name_.Swap(&other->name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  type_.Swap(&other->type_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  version_.Swap(&other->version_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata RegisteredComponents::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void SetMetadataRequest::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int SetMetadataRequest::kKeyFieldNumber;
+const int SetMetadataRequest::kValueFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+SetMetadataRequest::SetMetadataRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SetMetadataRequest.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.SetMetadataRequest)
+}
+SetMetadataRequest::SetMetadataRequest(const SetMetadataRequest& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.key().size() > 0) {
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.value().size() > 0) {
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.SetMetadataRequest)
+}
+
+void SetMetadataRequest::SharedCtor() {
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+SetMetadataRequest::~SetMetadataRequest() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.SetMetadataRequest)
+  SharedDtor();
+}
+
+void SetMetadataRequest::SharedDtor() {
+  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void SetMetadataRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* SetMetadataRequest::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const SetMetadataRequest& SetMetadataRequest::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SetMetadataRequest.base);
+  return *internal_default_instance();
+}
+
+
+void SetMetadataRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool SetMetadataRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string key = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_key()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->key().data(), static_cast<int>(this->key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SetMetadataRequest.key"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string value = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_value()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->value().data(), static_cast<int>(this->value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SetMetadataRequest.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.SetMetadataRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.SetMetadataRequest)
+  return false;
+#undef DO_
+}
+
+void SetMetadataRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SetMetadataRequest.key");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->key(), output);
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SetMetadataRequest.value");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->value(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.SetMetadataRequest)
+}
+
+::google::protobuf::uint8* SetMetadataRequest::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SetMetadataRequest.key");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->key(), target);
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SetMetadataRequest.value");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->value(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.SetMetadataRequest)
+  return target;
+}
+
+size_t SetMetadataRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string key = 1;
+  if (this->key().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->key());
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->value());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetMetadataRequest::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetMetadataRequest* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const SetMetadataRequest>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.SetMetadataRequest)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.SetMetadataRequest)
+    MergeFrom(*source);
+  }
+}
+
+void SetMetadataRequest::MergeFrom(const SetMetadataRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.key().size() > 0) {
+
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  if (from.value().size() > 0) {
+
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+}
+
+void SetMetadataRequest::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetMetadataRequest::CopyFrom(const SetMetadataRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.SetMetadataRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetMetadataRequest::IsInitialized() const {
+  return true;
+}
+
+void SetMetadataRequest::Swap(SetMetadataRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SetMetadataRequest::InternalSwap(SetMetadataRequest* other) {
+  using std::swap;
+  key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  value_.Swap(&other->value_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata SetMetadataRequest::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace v1
 }  // namespace runtime
@@ -12583,6 +14936,9 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::Delete
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::DeleteStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::DeleteStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::DeleteStateRequest >(arena);
 }
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::DeleteBulkStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::DeleteBulkStateRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::DeleteBulkStateRequest >(arena);
+}
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SaveStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SaveStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::SaveStateRequest >(arena);
 }
@@ -12621,6 +14977,12 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetBul
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetBulkSecretRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetBulkSecretRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetBulkSecretRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SecretResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SecretResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SecretResponse >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse >(arena);
@@ -12666,6 +15028,21 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::Invoke
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::InvokeActorResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::InvokeActorResponse >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::InvokeActorResponse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetMetadataResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetMetadataResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetMetadataResponse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::ActiveActorsCount* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::ActiveActorsCount >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::ActiveActorsCount >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::RegisteredComponents* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::RegisteredComponents >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::RegisteredComponents >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SetMetadataRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SetMetadataRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SetMetadataRequest >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/dapr/proto/runtime/v1/dapr.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.pb.h
@@ -44,7 +44,7 @@ namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[40];
+  static const ::google::protobuf::internal::ParseTable schema[48];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -55,12 +55,18 @@ namespace dapr {
 namespace proto {
 namespace runtime {
 namespace v1 {
+class ActiveActorsCount;
+class ActiveActorsCountDefaultTypeInternal;
+extern ActiveActorsCountDefaultTypeInternal _ActiveActorsCount_default_instance_;
 class BulkStateItem;
 class BulkStateItemDefaultTypeInternal;
 extern BulkStateItemDefaultTypeInternal _BulkStateItem_default_instance_;
 class BulkStateItem_MetadataEntry_DoNotUse;
 class BulkStateItem_MetadataEntry_DoNotUseDefaultTypeInternal;
 extern BulkStateItem_MetadataEntry_DoNotUseDefaultTypeInternal _BulkStateItem_MetadataEntry_DoNotUse_default_instance_;
+class DeleteBulkStateRequest;
+class DeleteBulkStateRequestDefaultTypeInternal;
+extern DeleteBulkStateRequestDefaultTypeInternal _DeleteBulkStateRequest_default_instance_;
 class DeleteStateRequest;
 class DeleteStateRequestDefaultTypeInternal;
 extern DeleteStateRequestDefaultTypeInternal _DeleteStateRequest_default_instance_;
@@ -103,6 +109,12 @@ extern GetBulkStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _GetBulkSta
 class GetBulkStateResponse;
 class GetBulkStateResponseDefaultTypeInternal;
 extern GetBulkStateResponseDefaultTypeInternal _GetBulkStateResponse_default_instance_;
+class GetMetadataResponse;
+class GetMetadataResponseDefaultTypeInternal;
+extern GetMetadataResponseDefaultTypeInternal _GetMetadataResponse_default_instance_;
+class GetMetadataResponse_ExtendedMetadataEntry_DoNotUse;
+class GetMetadataResponse_ExtendedMetadataEntry_DoNotUseDefaultTypeInternal;
+extern GetMetadataResponse_ExtendedMetadataEntry_DoNotUseDefaultTypeInternal _GetMetadataResponse_ExtendedMetadataEntry_DoNotUse_default_instance_;
 class GetSecretRequest;
 class GetSecretRequestDefaultTypeInternal;
 extern GetSecretRequestDefaultTypeInternal _GetSecretRequest_default_instance_;
@@ -160,9 +172,21 @@ extern RegisterActorReminderRequestDefaultTypeInternal _RegisterActorReminderReq
 class RegisterActorTimerRequest;
 class RegisterActorTimerRequestDefaultTypeInternal;
 extern RegisterActorTimerRequestDefaultTypeInternal _RegisterActorTimerRequest_default_instance_;
+class RegisteredComponents;
+class RegisteredComponentsDefaultTypeInternal;
+extern RegisteredComponentsDefaultTypeInternal _RegisteredComponents_default_instance_;
 class SaveStateRequest;
 class SaveStateRequestDefaultTypeInternal;
 extern SaveStateRequestDefaultTypeInternal _SaveStateRequest_default_instance_;
+class SecretResponse;
+class SecretResponseDefaultTypeInternal;
+extern SecretResponseDefaultTypeInternal _SecretResponse_default_instance_;
+class SecretResponse_SecretsEntry_DoNotUse;
+class SecretResponse_SecretsEntry_DoNotUseDefaultTypeInternal;
+extern SecretResponse_SecretsEntry_DoNotUseDefaultTypeInternal _SecretResponse_SecretsEntry_DoNotUse_default_instance_;
+class SetMetadataRequest;
+class SetMetadataRequestDefaultTypeInternal;
+extern SetMetadataRequestDefaultTypeInternal _SetMetadataRequest_default_instance_;
 class TransactionalActorStateOperation;
 class TransactionalActorStateOperationDefaultTypeInternal;
 extern TransactionalActorStateOperationDefaultTypeInternal _TransactionalActorStateOperation_default_instance_;
@@ -181,8 +205,10 @@ extern UnregisterActorTimerRequestDefaultTypeInternal _UnregisterActorTimerReque
 }  // namespace dapr
 namespace google {
 namespace protobuf {
+template<> ::dapr::proto::runtime::v1::ActiveActorsCount* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::ActiveActorsCount>(Arena*);
 template<> ::dapr::proto::runtime::v1::BulkStateItem* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::BulkStateItem>(Arena*);
 template<> ::dapr::proto::runtime::v1::BulkStateItem_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::BulkStateItem_MetadataEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::DeleteBulkStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::DeleteBulkStateRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::DeleteStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::DeleteStateRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::DeleteStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest>(Arena*);
@@ -197,6 +223,8 @@ template<> ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse*
 template<> ::dapr::proto::runtime::v1::GetBulkStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetMetadataResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetMetadataResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretResponse>(Arena*);
@@ -216,7 +244,11 @@ template<> ::dapr::proto::runtime::v1::PublishEventRequest* Arena::CreateMaybeMe
 template<> ::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::RegisterActorReminderRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisterActorReminderRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::RegisterActorTimerRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisterActorTimerRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::RegisteredComponents* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisteredComponents>(Arena*);
 template<> ::dapr::proto::runtime::v1::SaveStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SaveStateRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::SecretResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SecretResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::SetMetadataRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SetMetadataRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::TransactionalActorStateOperation* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TransactionalActorStateOperation>(Arena*);
 template<> ::dapr::proto::runtime::v1::TransactionalStateOperation* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TransactionalStateOperation>(Arena*);
 template<> ::dapr::proto::runtime::v1::UnregisterActorReminderRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::UnregisterActorReminderRequest>(Arena*);
@@ -1313,19 +1345,17 @@ class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insert
   ::std::string* release_key();
   void set_allocated_key(::std::string* key);
 
-  // string etag = 3;
+  // .dapr.proto.common.v1.Etag etag = 3;
+  bool has_etag() const;
   void clear_etag();
   static const int kEtagFieldNumber = 3;
-  const ::std::string& etag() const;
-  void set_etag(const ::std::string& value);
-  #if LANG_CXX11
-  void set_etag(::std::string&& value);
-  #endif
-  void set_etag(const char* value);
-  void set_etag(const char* value, size_t size);
-  ::std::string* mutable_etag();
-  ::std::string* release_etag();
-  void set_allocated_etag(::std::string* etag);
+  private:
+  const ::dapr::proto::common::v1::Etag& _internal_etag() const;
+  public:
+  const ::dapr::proto::common::v1::Etag& etag() const;
+  ::dapr::proto::common::v1::Etag* release_etag();
+  ::dapr::proto::common::v1::Etag* mutable_etag();
+  void set_allocated_etag(::dapr::proto::common::v1::Etag* etag);
 
   // .dapr.proto.common.v1.StateOptions options = 4;
   bool has_options() const;
@@ -1351,8 +1381,132 @@ class DeleteStateRequest : public ::google::protobuf::Message /* @@protoc_insert
       0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr store_name_;
   ::google::protobuf::internal::ArenaStringPtr key_;
-  ::google::protobuf::internal::ArenaStringPtr etag_;
+  ::dapr::proto::common::v1::Etag* etag_;
   ::dapr::proto::common::v1::StateOptions* options_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class DeleteBulkStateRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.DeleteBulkStateRequest) */ {
+ public:
+  DeleteBulkStateRequest();
+  virtual ~DeleteBulkStateRequest();
+
+  DeleteBulkStateRequest(const DeleteBulkStateRequest& from);
+
+  inline DeleteBulkStateRequest& operator=(const DeleteBulkStateRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  DeleteBulkStateRequest(DeleteBulkStateRequest&& from) noexcept
+    : DeleteBulkStateRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline DeleteBulkStateRequest& operator=(DeleteBulkStateRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const DeleteBulkStateRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const DeleteBulkStateRequest* internal_default_instance() {
+    return reinterpret_cast<const DeleteBulkStateRequest*>(
+               &_DeleteBulkStateRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    12;
+
+  void Swap(DeleteBulkStateRequest* other);
+  friend void swap(DeleteBulkStateRequest& a, DeleteBulkStateRequest& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline DeleteBulkStateRequest* New() const final {
+    return CreateMaybeMessage<DeleteBulkStateRequest>(NULL);
+  }
+
+  DeleteBulkStateRequest* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<DeleteBulkStateRequest>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const DeleteBulkStateRequest& from);
+  void MergeFrom(const DeleteBulkStateRequest& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DeleteBulkStateRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.common.v1.StateItem states = 2;
+  int states_size() const;
+  void clear_states();
+  static const int kStatesFieldNumber = 2;
+  ::dapr::proto::common::v1::StateItem* mutable_states(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::StateItem >*
+      mutable_states();
+  const ::dapr::proto::common::v1::StateItem& states(int index) const;
+  ::dapr::proto::common::v1::StateItem* add_states();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::StateItem >&
+      states() const;
+
+  // string store_name = 1;
+  void clear_store_name();
+  static const int kStoreNameFieldNumber = 1;
+  const ::std::string& store_name() const;
+  void set_store_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_store_name(::std::string&& value);
+  #endif
+  void set_store_name(const char* value);
+  void set_store_name(const char* value, size_t size);
+  ::std::string* mutable_store_name();
+  ::std::string* release_store_name();
+  void set_allocated_store_name(::std::string* store_name);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.DeleteBulkStateRequest)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::StateItem > states_;
+  ::google::protobuf::internal::ArenaStringPtr store_name_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -1393,7 +1547,7 @@ class SaveStateRequest : public ::google::protobuf::Message /* @@protoc_insertio
                &_SaveStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    13;
 
   void Swap(SaveStateRequest* other);
   friend void swap(SaveStateRequest& a, SaveStateRequest& b) {
@@ -1538,7 +1692,7 @@ class PublishEventRequest : public ::google::protobuf::Message /* @@protoc_inser
                &_PublishEventRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    15;
 
   void Swap(PublishEventRequest* other);
   friend void swap(PublishEventRequest& a, PublishEventRequest& b) {
@@ -1731,7 +1885,7 @@ class InvokeBindingRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_InvokeBindingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    17;
 
   void Swap(InvokeBindingRequest* other);
   friend void swap(InvokeBindingRequest& a, InvokeBindingRequest& b) {
@@ -1909,7 +2063,7 @@ class InvokeBindingResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_InvokeBindingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    19;
 
   void Swap(InvokeBindingResponse* other);
   friend void swap(InvokeBindingResponse& a, InvokeBindingResponse& b) {
@@ -2057,7 +2211,7 @@ class GetSecretRequest : public ::google::protobuf::Message /* @@protoc_insertio
                &_GetSecretRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    21;
 
   void Swap(GetSecretRequest* other);
   friend void swap(GetSecretRequest& a, GetSecretRequest& b) {
@@ -2220,7 +2374,7 @@ class GetSecretResponse : public ::google::protobuf::Message /* @@protoc_inserti
                &_GetSecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    23;
 
   void Swap(GetSecretResponse* other);
   friend void swap(GetSecretResponse& a, GetSecretResponse& b) {
@@ -2353,7 +2507,7 @@ class GetBulkSecretRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_GetBulkSecretRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    25;
 
   void Swap(GetBulkSecretRequest* other);
   friend void swap(GetBulkSecretRequest& a, GetBulkSecretRequest& b) {
@@ -2445,16 +2599,149 @@ class GetBulkSecretRequest : public ::google::protobuf::Message /* @@protoc_inse
 };
 // -------------------------------------------------------------------
 
-class GetBulkSecretResponse_DataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetBulkSecretResponse_DataEntry_DoNotUse, 
+class SecretResponse_SecretsEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<SecretResponse_SecretsEntry_DoNotUse, 
     ::std::string, ::std::string,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     0 > {
 public:
-  typedef ::google::protobuf::internal::MapEntry<GetBulkSecretResponse_DataEntry_DoNotUse, 
+  typedef ::google::protobuf::internal::MapEntry<SecretResponse_SecretsEntry_DoNotUse, 
     ::std::string, ::std::string,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  SecretResponse_SecretsEntry_DoNotUse();
+  SecretResponse_SecretsEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const SecretResponse_SecretsEntry_DoNotUse& other);
+  static const SecretResponse_SecretsEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const SecretResponse_SecretsEntry_DoNotUse*>(&_SecretResponse_SecretsEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class SecretResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.SecretResponse) */ {
+ public:
+  SecretResponse();
+  virtual ~SecretResponse();
+
+  SecretResponse(const SecretResponse& from);
+
+  inline SecretResponse& operator=(const SecretResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  SecretResponse(SecretResponse&& from) noexcept
+    : SecretResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SecretResponse& operator=(SecretResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SecretResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SecretResponse* internal_default_instance() {
+    return reinterpret_cast<const SecretResponse*>(
+               &_SecretResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    27;
+
+  void Swap(SecretResponse* other);
+  friend void swap(SecretResponse& a, SecretResponse& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SecretResponse* New() const final {
+    return CreateMaybeMessage<SecretResponse>(NULL);
+  }
+
+  SecretResponse* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<SecretResponse>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const SecretResponse& from);
+  void MergeFrom(const SecretResponse& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SecretResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // map<string, string> secrets = 1;
+  int secrets_size() const;
+  void clear_secrets();
+  static const int kSecretsFieldNumber = 1;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      secrets() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_secrets();
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.SecretResponse)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      SecretResponse_SecretsEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > secrets_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class GetBulkSecretResponse_DataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetBulkSecretResponse_DataEntry_DoNotUse, 
+    ::std::string, ::dapr::proto::runtime::v1::SecretResponse,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GetBulkSecretResponse_DataEntry_DoNotUse, 
+    ::std::string, ::dapr::proto::runtime::v1::SecretResponse,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > SuperType;
   GetBulkSecretResponse_DataEntry_DoNotUse();
   GetBulkSecretResponse_DataEntry_DoNotUse(::google::protobuf::Arena* arena);
@@ -2501,7 +2788,7 @@ class GetBulkSecretResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_GetBulkSecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    29;
 
   void Swap(GetBulkSecretResponse* other);
   friend void swap(GetBulkSecretResponse& a, GetBulkSecretResponse& b) {
@@ -2554,13 +2841,13 @@ class GetBulkSecretResponse : public ::google::protobuf::Message /* @@protoc_ins
 
   // accessors -------------------------------------------------------
 
-  // map<string, string> data = 1;
+  // map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
   int data_size() const;
   void clear_data();
   static const int kDataFieldNumber = 1;
-  const ::google::protobuf::Map< ::std::string, ::std::string >&
+  const ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >&
       data() const;
-  ::google::protobuf::Map< ::std::string, ::std::string >*
+  ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >*
       mutable_data();
 
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.GetBulkSecretResponse)
@@ -2569,9 +2856,9 @@ class GetBulkSecretResponse : public ::google::protobuf::Message /* @@protoc_ins
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::MapField<
       GetBulkSecretResponse_DataEntry_DoNotUse,
-      ::std::string, ::std::string,
+      ::std::string, ::dapr::proto::runtime::v1::SecretResponse,
       ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
-      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
       0 > data_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
@@ -2613,7 +2900,7 @@ class TransactionalStateOperation : public ::google::protobuf::Message /* @@prot
                &_TransactionalStateOperation_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    30;
 
   void Swap(TransactionalStateOperation* other);
   friend void swap(TransactionalStateOperation& a, TransactionalStateOperation& b) {
@@ -2758,7 +3045,7 @@ class ExecuteStateTransactionRequest : public ::google::protobuf::Message /* @@p
                &_ExecuteStateTransactionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    32;
 
   void Swap(ExecuteStateTransactionRequest* other);
   friend void swap(ExecuteStateTransactionRequest& a, ExecuteStateTransactionRequest& b) {
@@ -2898,7 +3185,7 @@ class RegisterActorTimerRequest : public ::google::protobuf::Message /* @@protoc
                &_RegisterActorTimerRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    33;
 
   void Swap(RegisterActorTimerRequest* other);
   friend void swap(RegisterActorTimerRequest& a, RegisterActorTimerRequest& b) {
@@ -3099,7 +3386,7 @@ class UnregisterActorTimerRequest : public ::google::protobuf::Message /* @@prot
                &_UnregisterActorTimerRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    31;
+    34;
 
   void Swap(UnregisterActorTimerRequest* other);
   friend void swap(UnregisterActorTimerRequest& a, UnregisterActorTimerRequest& b) {
@@ -3240,7 +3527,7 @@ class RegisterActorReminderRequest : public ::google::protobuf::Message /* @@pro
                &_RegisterActorReminderRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    35;
 
   void Swap(RegisterActorReminderRequest* other);
   friend void swap(RegisterActorReminderRequest& a, RegisterActorReminderRequest& b) {
@@ -3426,7 +3713,7 @@ class UnregisterActorReminderRequest : public ::google::protobuf::Message /* @@p
                &_UnregisterActorReminderRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    36;
 
   void Swap(UnregisterActorReminderRequest* other);
   friend void swap(UnregisterActorReminderRequest& a, UnregisterActorReminderRequest& b) {
@@ -3567,7 +3854,7 @@ class GetActorStateRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_GetActorStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    37;
 
   void Swap(GetActorStateRequest* other);
   friend void swap(GetActorStateRequest& a, GetActorStateRequest& b) {
@@ -3708,7 +3995,7 @@ class GetActorStateResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_GetActorStateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    35;
+    38;
 
   void Swap(GetActorStateResponse* other);
   friend void swap(GetActorStateResponse& a, GetActorStateResponse& b) {
@@ -3819,7 +4106,7 @@ class ExecuteActorStateTransactionRequest : public ::google::protobuf::Message /
                &_ExecuteActorStateTransactionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    36;
+    39;
 
   void Swap(ExecuteActorStateTransactionRequest* other);
   friend void swap(ExecuteActorStateTransactionRequest& a, ExecuteActorStateTransactionRequest& b) {
@@ -3958,7 +4245,7 @@ class TransactionalActorStateOperation : public ::google::protobuf::Message /* @
                &_TransactionalActorStateOperation_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    37;
+    40;
 
   void Swap(TransactionalActorStateOperation* other);
   friend void swap(TransactionalActorStateOperation& a, TransactionalActorStateOperation& b) {
@@ -4097,7 +4384,7 @@ class InvokeActorRequest : public ::google::protobuf::Message /* @@protoc_insert
                &_InvokeActorRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    38;
+    41;
 
   void Swap(InvokeActorRequest* other);
   friend void swap(InvokeActorRequest& a, InvokeActorRequest& b) {
@@ -4253,7 +4540,7 @@ class InvokeActorResponse : public ::google::protobuf::Message /* @@protoc_inser
                &_InvokeActorResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    39;
+    42;
 
   void Swap(InvokeActorResponse* other);
   friend void swap(InvokeActorResponse& a, InvokeActorResponse& b) {
@@ -4324,6 +4611,565 @@ class InvokeActorResponse : public ::google::protobuf::Message /* @@protoc_inser
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::ArenaStringPtr data_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class GetMetadataResponse_ExtendedMetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GetMetadataResponse_ExtendedMetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GetMetadataResponse_ExtendedMetadataEntry_DoNotUse();
+  GetMetadataResponse_ExtendedMetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GetMetadataResponse_ExtendedMetadataEntry_DoNotUse& other);
+  static const GetMetadataResponse_ExtendedMetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GetMetadataResponse_ExtendedMetadataEntry_DoNotUse*>(&_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class GetMetadataResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.GetMetadataResponse) */ {
+ public:
+  GetMetadataResponse();
+  virtual ~GetMetadataResponse();
+
+  GetMetadataResponse(const GetMetadataResponse& from);
+
+  inline GetMetadataResponse& operator=(const GetMetadataResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GetMetadataResponse(GetMetadataResponse&& from) noexcept
+    : GetMetadataResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline GetMetadataResponse& operator=(GetMetadataResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GetMetadataResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GetMetadataResponse* internal_default_instance() {
+    return reinterpret_cast<const GetMetadataResponse*>(
+               &_GetMetadataResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    44;
+
+  void Swap(GetMetadataResponse* other);
+  friend void swap(GetMetadataResponse& a, GetMetadataResponse& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GetMetadataResponse* New() const final {
+    return CreateMaybeMessage<GetMetadataResponse>(NULL);
+  }
+
+  GetMetadataResponse* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<GetMetadataResponse>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const GetMetadataResponse& from);
+  void MergeFrom(const GetMetadataResponse& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GetMetadataResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+  int active_actors_count_size() const;
+  void clear_active_actors_count();
+  static const int kActiveActorsCountFieldNumber = 2;
+  ::dapr::proto::runtime::v1::ActiveActorsCount* mutable_active_actors_count(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::ActiveActorsCount >*
+      mutable_active_actors_count();
+  const ::dapr::proto::runtime::v1::ActiveActorsCount& active_actors_count(int index) const;
+  ::dapr::proto::runtime::v1::ActiveActorsCount* add_active_actors_count();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::ActiveActorsCount >&
+      active_actors_count() const;
+
+  // repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+  int registered_components_size() const;
+  void clear_registered_components();
+  static const int kRegisteredComponentsFieldNumber = 3;
+  ::dapr::proto::runtime::v1::RegisteredComponents* mutable_registered_components(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::RegisteredComponents >*
+      mutable_registered_components();
+  const ::dapr::proto::runtime::v1::RegisteredComponents& registered_components(int index) const;
+  ::dapr::proto::runtime::v1::RegisteredComponents* add_registered_components();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::RegisteredComponents >&
+      registered_components() const;
+
+  // map<string, string> extended_metadata = 4;
+  int extended_metadata_size() const;
+  void clear_extended_metadata();
+  static const int kExtendedMetadataFieldNumber = 4;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      extended_metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_extended_metadata();
+
+  // string id = 1;
+  void clear_id();
+  static const int kIdFieldNumber = 1;
+  const ::std::string& id() const;
+  void set_id(const ::std::string& value);
+  #if LANG_CXX11
+  void set_id(::std::string&& value);
+  #endif
+  void set_id(const char* value);
+  void set_id(const char* value, size_t size);
+  ::std::string* mutable_id();
+  ::std::string* release_id();
+  void set_allocated_id(::std::string* id);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.GetMetadataResponse)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::ActiveActorsCount > active_actors_count_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::RegisteredComponents > registered_components_;
+  ::google::protobuf::internal::MapField<
+      GetMetadataResponse_ExtendedMetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > extended_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr id_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ActiveActorsCount : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.ActiveActorsCount) */ {
+ public:
+  ActiveActorsCount();
+  virtual ~ActiveActorsCount();
+
+  ActiveActorsCount(const ActiveActorsCount& from);
+
+  inline ActiveActorsCount& operator=(const ActiveActorsCount& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ActiveActorsCount(ActiveActorsCount&& from) noexcept
+    : ActiveActorsCount() {
+    *this = ::std::move(from);
+  }
+
+  inline ActiveActorsCount& operator=(ActiveActorsCount&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ActiveActorsCount& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ActiveActorsCount* internal_default_instance() {
+    return reinterpret_cast<const ActiveActorsCount*>(
+               &_ActiveActorsCount_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    45;
+
+  void Swap(ActiveActorsCount* other);
+  friend void swap(ActiveActorsCount& a, ActiveActorsCount& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ActiveActorsCount* New() const final {
+    return CreateMaybeMessage<ActiveActorsCount>(NULL);
+  }
+
+  ActiveActorsCount* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ActiveActorsCount>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ActiveActorsCount& from);
+  void MergeFrom(const ActiveActorsCount& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ActiveActorsCount* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string type = 1;
+  void clear_type();
+  static const int kTypeFieldNumber = 1;
+  const ::std::string& type() const;
+  void set_type(const ::std::string& value);
+  #if LANG_CXX11
+  void set_type(::std::string&& value);
+  #endif
+  void set_type(const char* value);
+  void set_type(const char* value, size_t size);
+  ::std::string* mutable_type();
+  ::std::string* release_type();
+  void set_allocated_type(::std::string* type);
+
+  // int32 count = 2;
+  void clear_count();
+  static const int kCountFieldNumber = 2;
+  ::google::protobuf::int32 count() const;
+  void set_count(::google::protobuf::int32 value);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.ActiveActorsCount)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr type_;
+  ::google::protobuf::int32 count_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class RegisteredComponents : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.RegisteredComponents) */ {
+ public:
+  RegisteredComponents();
+  virtual ~RegisteredComponents();
+
+  RegisteredComponents(const RegisteredComponents& from);
+
+  inline RegisteredComponents& operator=(const RegisteredComponents& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  RegisteredComponents(RegisteredComponents&& from) noexcept
+    : RegisteredComponents() {
+    *this = ::std::move(from);
+  }
+
+  inline RegisteredComponents& operator=(RegisteredComponents&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RegisteredComponents& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RegisteredComponents* internal_default_instance() {
+    return reinterpret_cast<const RegisteredComponents*>(
+               &_RegisteredComponents_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    46;
+
+  void Swap(RegisteredComponents* other);
+  friend void swap(RegisteredComponents& a, RegisteredComponents& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RegisteredComponents* New() const final {
+    return CreateMaybeMessage<RegisteredComponents>(NULL);
+  }
+
+  RegisteredComponents* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<RegisteredComponents>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const RegisteredComponents& from);
+  void MergeFrom(const RegisteredComponents& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RegisteredComponents* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string name = 1;
+  void clear_name();
+  static const int kNameFieldNumber = 1;
+  const ::std::string& name() const;
+  void set_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_name(::std::string&& value);
+  #endif
+  void set_name(const char* value);
+  void set_name(const char* value, size_t size);
+  ::std::string* mutable_name();
+  ::std::string* release_name();
+  void set_allocated_name(::std::string* name);
+
+  // string type = 2;
+  void clear_type();
+  static const int kTypeFieldNumber = 2;
+  const ::std::string& type() const;
+  void set_type(const ::std::string& value);
+  #if LANG_CXX11
+  void set_type(::std::string&& value);
+  #endif
+  void set_type(const char* value);
+  void set_type(const char* value, size_t size);
+  ::std::string* mutable_type();
+  ::std::string* release_type();
+  void set_allocated_type(::std::string* type);
+
+  // string version = 3;
+  void clear_version();
+  static const int kVersionFieldNumber = 3;
+  const ::std::string& version() const;
+  void set_version(const ::std::string& value);
+  #if LANG_CXX11
+  void set_version(::std::string&& value);
+  #endif
+  void set_version(const char* value);
+  void set_version(const char* value, size_t size);
+  ::std::string* mutable_version();
+  ::std::string* release_version();
+  void set_allocated_version(::std::string* version);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.RegisteredComponents)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr name_;
+  ::google::protobuf::internal::ArenaStringPtr type_;
+  ::google::protobuf::internal::ArenaStringPtr version_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class SetMetadataRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.SetMetadataRequest) */ {
+ public:
+  SetMetadataRequest();
+  virtual ~SetMetadataRequest();
+
+  SetMetadataRequest(const SetMetadataRequest& from);
+
+  inline SetMetadataRequest& operator=(const SetMetadataRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  SetMetadataRequest(SetMetadataRequest&& from) noexcept
+    : SetMetadataRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SetMetadataRequest& operator=(SetMetadataRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SetMetadataRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SetMetadataRequest* internal_default_instance() {
+    return reinterpret_cast<const SetMetadataRequest*>(
+               &_SetMetadataRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    47;
+
+  void Swap(SetMetadataRequest* other);
+  friend void swap(SetMetadataRequest& a, SetMetadataRequest& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetMetadataRequest* New() const final {
+    return CreateMaybeMessage<SetMetadataRequest>(NULL);
+  }
+
+  SetMetadataRequest* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<SetMetadataRequest>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const SetMetadataRequest& from);
+  void MergeFrom(const SetMetadataRequest& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetMetadataRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string key = 1;
+  void clear_key();
+  static const int kKeyFieldNumber = 1;
+  const ::std::string& key() const;
+  void set_key(const ::std::string& value);
+  #if LANG_CXX11
+  void set_key(::std::string&& value);
+  #endif
+  void set_key(const char* value);
+  void set_key(const char* value, size_t size);
+  ::std::string* mutable_key();
+  ::std::string* release_key();
+  void set_allocated_key(::std::string* key);
+
+  // string value = 2;
+  void clear_value();
+  static const int kValueFieldNumber = 2;
+  const ::std::string& value() const;
+  void set_value(const ::std::string& value);
+  #if LANG_CXX11
+  void set_value(::std::string&& value);
+  #endif
+  void set_value(const char* value);
+  void set_value(const char* value, size_t size);
+  ::std::string* mutable_value();
+  ::std::string* release_value();
+  void set_allocated_value(::std::string* value);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.SetMetadataRequest)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr value_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -5255,56 +6101,51 @@ inline void DeleteStateRequest::set_allocated_key(::std::string* key) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.DeleteStateRequest.key)
 }
 
-// string etag = 3;
-inline void DeleteStateRequest::clear_etag() {
-  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// .dapr.proto.common.v1.Etag etag = 3;
+inline bool DeleteStateRequest::has_etag() const {
+  return this != internal_default_instance() && etag_ != NULL;
 }
-inline const ::std::string& DeleteStateRequest::etag() const {
+inline const ::dapr::proto::common::v1::Etag& DeleteStateRequest::_internal_etag() const {
+  return *etag_;
+}
+inline const ::dapr::proto::common::v1::Etag& DeleteStateRequest::etag() const {
+  const ::dapr::proto::common::v1::Etag* p = etag_;
   // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-  return etag_.GetNoArena();
+  return p != NULL ? *p : *reinterpret_cast<const ::dapr::proto::common::v1::Etag*>(
+      &::dapr::proto::common::v1::_Etag_default_instance_);
 }
-inline void DeleteStateRequest::set_etag(const ::std::string& value) {
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-}
-#if LANG_CXX11
-inline void DeleteStateRequest::set_etag(::std::string&& value) {
-  
-  etag_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-}
-#endif
-inline void DeleteStateRequest::set_etag(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-}
-inline void DeleteStateRequest::set_etag(const char* value, size_t size) {
-  
-  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-}
-inline ::std::string* DeleteStateRequest::mutable_etag() {
-  
-  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.DeleteStateRequest.etag)
-  return etag_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* DeleteStateRequest::release_etag() {
+inline ::dapr::proto::common::v1::Etag* DeleteStateRequest::release_etag() {
   // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.DeleteStateRequest.etag)
   
-  return etag_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::dapr::proto::common::v1::Etag* temp = etag_;
+  etag_ = NULL;
+  return temp;
 }
-inline void DeleteStateRequest::set_allocated_etag(::std::string* etag) {
-  if (etag != NULL) {
+inline ::dapr::proto::common::v1::Etag* DeleteStateRequest::mutable_etag() {
+  
+  if (etag_ == NULL) {
+    auto* p = CreateMaybeMessage<::dapr::proto::common::v1::Etag>(GetArenaNoVirtual());
+    etag_ = p;
+  }
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.DeleteStateRequest.etag)
+  return etag_;
+}
+inline void DeleteStateRequest::set_allocated_etag(::dapr::proto::common::v1::Etag* etag) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete reinterpret_cast< ::google::protobuf::MessageLite*>(etag_);
+  }
+  if (etag) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      etag = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, etag, submessage_arena);
+    }
     
   } else {
     
   }
-  etag_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), etag);
+  etag_ = etag;
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.DeleteStateRequest.etag)
 }
 
@@ -5372,6 +6213,90 @@ inline ::google::protobuf::Map< ::std::string, ::std::string >*
 DeleteStateRequest::mutable_metadata() {
   // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.DeleteStateRequest.metadata)
   return metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// DeleteBulkStateRequest
+
+// string store_name = 1;
+inline void DeleteBulkStateRequest::clear_store_name() {
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& DeleteBulkStateRequest::store_name() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+  return store_name_.GetNoArena();
+}
+inline void DeleteBulkStateRequest::set_store_name(const ::std::string& value) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+}
+#if LANG_CXX11
+inline void DeleteBulkStateRequest::set_store_name(::std::string&& value) {
+  
+  store_name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+}
+#endif
+inline void DeleteBulkStateRequest::set_store_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+}
+inline void DeleteBulkStateRequest::set_store_name(const char* value, size_t size) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+}
+inline ::std::string* DeleteBulkStateRequest::mutable_store_name() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+  return store_name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* DeleteBulkStateRequest::release_store_name() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+  
+  return store_name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void DeleteBulkStateRequest::set_allocated_store_name(::std::string* store_name) {
+  if (store_name != NULL) {
+    
+  } else {
+    
+  }
+  store_name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), store_name);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.DeleteBulkStateRequest.store_name)
+}
+
+// repeated .dapr.proto.common.v1.StateItem states = 2;
+inline int DeleteBulkStateRequest::states_size() const {
+  return states_.size();
+}
+inline ::dapr::proto::common::v1::StateItem* DeleteBulkStateRequest::mutable_states(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.DeleteBulkStateRequest.states)
+  return states_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::StateItem >*
+DeleteBulkStateRequest::mutable_states() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.DeleteBulkStateRequest.states)
+  return &states_;
+}
+inline const ::dapr::proto::common::v1::StateItem& DeleteBulkStateRequest::states(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.DeleteBulkStateRequest.states)
+  return states_.Get(index);
+}
+inline ::dapr::proto::common::v1::StateItem* DeleteBulkStateRequest::add_states() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.DeleteBulkStateRequest.states)
+  return states_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::StateItem >&
+DeleteBulkStateRequest::states() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.DeleteBulkStateRequest.states)
+  return states_;
 }
 
 // -------------------------------------------------------------------
@@ -6189,21 +7114,45 @@ GetBulkSecretRequest::mutable_metadata() {
 
 // -------------------------------------------------------------------
 
+// SecretResponse
+
+// map<string, string> secrets = 1;
+inline int SecretResponse::secrets_size() const {
+  return secrets_.size();
+}
+inline void SecretResponse::clear_secrets() {
+  secrets_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+SecretResponse::secrets() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.SecretResponse.secrets)
+  return secrets_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+SecretResponse::mutable_secrets() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.SecretResponse.secrets)
+  return secrets_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // GetBulkSecretResponse
 
-// map<string, string> data = 1;
+// map<string, .dapr.proto.runtime.v1.SecretResponse> data = 1;
 inline int GetBulkSecretResponse::data_size() const {
   return data_.size();
 }
 inline void GetBulkSecretResponse::clear_data() {
   data_.Clear();
 }
-inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+inline const ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >&
 GetBulkSecretResponse::data() const {
   // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.GetBulkSecretResponse.data)
   return data_.GetMap();
 }
-inline ::google::protobuf::Map< ::std::string, ::std::string >*
+inline ::google::protobuf::Map< ::std::string, ::dapr::proto::runtime::v1::SecretResponse >*
 GetBulkSecretResponse::mutable_data() {
   // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.GetBulkSecretResponse.data)
   return data_.MutableMap();
@@ -8235,9 +9184,506 @@ inline void InvokeActorResponse::set_allocated_data(::std::string* data) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.InvokeActorResponse.data)
 }
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// GetMetadataResponse
+
+// string id = 1;
+inline void GetMetadataResponse::clear_id() {
+  id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GetMetadataResponse::id() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetMetadataResponse.id)
+  return id_.GetNoArena();
+}
+inline void GetMetadataResponse::set_id(const ::std::string& value) {
+  
+  id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetMetadataResponse.id)
+}
+#if LANG_CXX11
+inline void GetMetadataResponse::set_id(::std::string&& value) {
+  
+  id_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.GetMetadataResponse.id)
+}
+#endif
+inline void GetMetadataResponse::set_id(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.GetMetadataResponse.id)
+}
+inline void GetMetadataResponse::set_id(const char* value, size_t size) {
+  
+  id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.GetMetadataResponse.id)
+}
+inline ::std::string* GetMetadataResponse::mutable_id() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetMetadataResponse.id)
+  return id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GetMetadataResponse::release_id() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.GetMetadataResponse.id)
+  
+  return id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GetMetadataResponse::set_allocated_id(::std::string* id) {
+  if (id != NULL) {
+    
+  } else {
+    
+  }
+  id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), id);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.GetMetadataResponse.id)
+}
+
+// repeated .dapr.proto.runtime.v1.ActiveActorsCount active_actors_count = 2;
+inline int GetMetadataResponse::active_actors_count_size() const {
+  return active_actors_count_.size();
+}
+inline void GetMetadataResponse::clear_active_actors_count() {
+  active_actors_count_.Clear();
+}
+inline ::dapr::proto::runtime::v1::ActiveActorsCount* GetMetadataResponse::mutable_active_actors_count(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetMetadataResponse.active_actors_count)
+  return active_actors_count_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::ActiveActorsCount >*
+GetMetadataResponse::mutable_active_actors_count() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.GetMetadataResponse.active_actors_count)
+  return &active_actors_count_;
+}
+inline const ::dapr::proto::runtime::v1::ActiveActorsCount& GetMetadataResponse::active_actors_count(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetMetadataResponse.active_actors_count)
+  return active_actors_count_.Get(index);
+}
+inline ::dapr::proto::runtime::v1::ActiveActorsCount* GetMetadataResponse::add_active_actors_count() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.GetMetadataResponse.active_actors_count)
+  return active_actors_count_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::ActiveActorsCount >&
+GetMetadataResponse::active_actors_count() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.GetMetadataResponse.active_actors_count)
+  return active_actors_count_;
+}
+
+// repeated .dapr.proto.runtime.v1.RegisteredComponents registered_components = 3;
+inline int GetMetadataResponse::registered_components_size() const {
+  return registered_components_.size();
+}
+inline void GetMetadataResponse::clear_registered_components() {
+  registered_components_.Clear();
+}
+inline ::dapr::proto::runtime::v1::RegisteredComponents* GetMetadataResponse::mutable_registered_components(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetMetadataResponse.registered_components)
+  return registered_components_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::RegisteredComponents >*
+GetMetadataResponse::mutable_registered_components() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.GetMetadataResponse.registered_components)
+  return &registered_components_;
+}
+inline const ::dapr::proto::runtime::v1::RegisteredComponents& GetMetadataResponse::registered_components(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetMetadataResponse.registered_components)
+  return registered_components_.Get(index);
+}
+inline ::dapr::proto::runtime::v1::RegisteredComponents* GetMetadataResponse::add_registered_components() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.GetMetadataResponse.registered_components)
+  return registered_components_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::RegisteredComponents >&
+GetMetadataResponse::registered_components() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.GetMetadataResponse.registered_components)
+  return registered_components_;
+}
+
+// map<string, string> extended_metadata = 4;
+inline int GetMetadataResponse::extended_metadata_size() const {
+  return extended_metadata_.size();
+}
+inline void GetMetadataResponse::clear_extended_metadata() {
+  extended_metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GetMetadataResponse::extended_metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.GetMetadataResponse.extended_metadata)
+  return extended_metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GetMetadataResponse::mutable_extended_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.GetMetadataResponse.extended_metadata)
+  return extended_metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// ActiveActorsCount
+
+// string type = 1;
+inline void ActiveActorsCount::clear_type() {
+  type_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ActiveActorsCount::type() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.ActiveActorsCount.type)
+  return type_.GetNoArena();
+}
+inline void ActiveActorsCount::set_type(const ::std::string& value) {
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.ActiveActorsCount.type)
+}
+#if LANG_CXX11
+inline void ActiveActorsCount::set_type(::std::string&& value) {
+  
+  type_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.ActiveActorsCount.type)
+}
+#endif
+inline void ActiveActorsCount::set_type(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.ActiveActorsCount.type)
+}
+inline void ActiveActorsCount::set_type(const char* value, size_t size) {
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.ActiveActorsCount.type)
+}
+inline ::std::string* ActiveActorsCount::mutable_type() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.ActiveActorsCount.type)
+  return type_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ActiveActorsCount::release_type() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.ActiveActorsCount.type)
+  
+  return type_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ActiveActorsCount::set_allocated_type(::std::string* type) {
+  if (type != NULL) {
+    
+  } else {
+    
+  }
+  type_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), type);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.ActiveActorsCount.type)
+}
+
+// int32 count = 2;
+inline void ActiveActorsCount::clear_count() {
+  count_ = 0;
+}
+inline ::google::protobuf::int32 ActiveActorsCount::count() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.ActiveActorsCount.count)
+  return count_;
+}
+inline void ActiveActorsCount::set_count(::google::protobuf::int32 value) {
+  
+  count_ = value;
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.ActiveActorsCount.count)
+}
+
+// -------------------------------------------------------------------
+
+// RegisteredComponents
+
+// string name = 1;
+inline void RegisteredComponents::clear_name() {
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RegisteredComponents::name() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.RegisteredComponents.name)
+  return name_.GetNoArena();
+}
+inline void RegisteredComponents::set_name(const ::std::string& value) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.RegisteredComponents.name)
+}
+#if LANG_CXX11
+inline void RegisteredComponents::set_name(::std::string&& value) {
+  
+  name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.RegisteredComponents.name)
+}
+#endif
+inline void RegisteredComponents::set_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.RegisteredComponents.name)
+}
+inline void RegisteredComponents::set_name(const char* value, size_t size) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.RegisteredComponents.name)
+}
+inline ::std::string* RegisteredComponents::mutable_name() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.RegisteredComponents.name)
+  return name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RegisteredComponents::release_name() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.RegisteredComponents.name)
+  
+  return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RegisteredComponents::set_allocated_name(::std::string* name) {
+  if (name != NULL) {
+    
+  } else {
+    
+  }
+  name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisteredComponents.name)
+}
+
+// string type = 2;
+inline void RegisteredComponents::clear_type() {
+  type_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RegisteredComponents::type() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.RegisteredComponents.type)
+  return type_.GetNoArena();
+}
+inline void RegisteredComponents::set_type(const ::std::string& value) {
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.RegisteredComponents.type)
+}
+#if LANG_CXX11
+inline void RegisteredComponents::set_type(::std::string&& value) {
+  
+  type_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.RegisteredComponents.type)
+}
+#endif
+inline void RegisteredComponents::set_type(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.RegisteredComponents.type)
+}
+inline void RegisteredComponents::set_type(const char* value, size_t size) {
+  
+  type_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.RegisteredComponents.type)
+}
+inline ::std::string* RegisteredComponents::mutable_type() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.RegisteredComponents.type)
+  return type_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RegisteredComponents::release_type() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.RegisteredComponents.type)
+  
+  return type_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RegisteredComponents::set_allocated_type(::std::string* type) {
+  if (type != NULL) {
+    
+  } else {
+    
+  }
+  type_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), type);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisteredComponents.type)
+}
+
+// string version = 3;
+inline void RegisteredComponents::clear_version() {
+  version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RegisteredComponents::version() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.RegisteredComponents.version)
+  return version_.GetNoArena();
+}
+inline void RegisteredComponents::set_version(const ::std::string& value) {
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.RegisteredComponents.version)
+}
+#if LANG_CXX11
+inline void RegisteredComponents::set_version(::std::string&& value) {
+  
+  version_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.RegisteredComponents.version)
+}
+#endif
+inline void RegisteredComponents::set_version(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.RegisteredComponents.version)
+}
+inline void RegisteredComponents::set_version(const char* value, size_t size) {
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.RegisteredComponents.version)
+}
+inline ::std::string* RegisteredComponents::mutable_version() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.RegisteredComponents.version)
+  return version_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RegisteredComponents::release_version() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.RegisteredComponents.version)
+  
+  return version_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RegisteredComponents::set_allocated_version(::std::string* version) {
+  if (version != NULL) {
+    
+  } else {
+    
+  }
+  version_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), version);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisteredComponents.version)
+}
+
+// -------------------------------------------------------------------
+
+// SetMetadataRequest
+
+// string key = 1;
+inline void SetMetadataRequest::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& SetMetadataRequest::key() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.SetMetadataRequest.key)
+  return key_.GetNoArena();
+}
+inline void SetMetadataRequest::set_key(const ::std::string& value) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.SetMetadataRequest.key)
+}
+#if LANG_CXX11
+inline void SetMetadataRequest::set_key(::std::string&& value) {
+  
+  key_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.SetMetadataRequest.key)
+}
+#endif
+inline void SetMetadataRequest::set_key(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.SetMetadataRequest.key)
+}
+inline void SetMetadataRequest::set_key(const char* value, size_t size) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.SetMetadataRequest.key)
+}
+inline ::std::string* SetMetadataRequest::mutable_key() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.SetMetadataRequest.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* SetMetadataRequest::release_key() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.SetMetadataRequest.key)
+  
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void SetMetadataRequest::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    
+  } else {
+    
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.SetMetadataRequest.key)
+}
+
+// string value = 2;
+inline void SetMetadataRequest::clear_value() {
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& SetMetadataRequest::value() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.SetMetadataRequest.value)
+  return value_.GetNoArena();
+}
+inline void SetMetadataRequest::set_value(const ::std::string& value) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.SetMetadataRequest.value)
+}
+#if LANG_CXX11
+inline void SetMetadataRequest::set_value(::std::string&& value) {
+  
+  value_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.SetMetadataRequest.value)
+}
+#endif
+inline void SetMetadataRequest::set_value(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.SetMetadataRequest.value)
+}
+inline void SetMetadataRequest::set_value(const char* value, size_t size) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.SetMetadataRequest.value)
+}
+inline ::std::string* SetMetadataRequest::mutable_value() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.SetMetadataRequest.value)
+  return value_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* SetMetadataRequest::release_value() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.SetMetadataRequest.value)
+  
+  return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void SetMetadataRequest::set_allocated_value(::std::string* value) {
+  if (value != NULL) {
+    
+  } else {
+    
+  }
+  value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.SetMetadataRequest.value)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Also added mechanical markdown.

closes: #24 

Validation:

```bash
/workspaces/cpp-sdk/examples/echo_app# mm.py README.md 
Running shell 'bash -c' with command: `make`
Running shell 'bash -c' with command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
Running shell 'bash -c' with command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
Running shell 'bash -c' with command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
Step: Build example
	command: `make`
	return_code: 0
	Expected stdout:
	Actual stdout:
		make: Nothing to be done for 'all'.
		
	Expected stderr:
	Actual stderr:
		
Step: Run callee
	command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
	return_code: 0
	Expected stdout:
		== APP == OnInvoke() is called
		== APP == Got the message: hello dapr
	Actual stdout:
		ℹ️  Starting Dapr with id callee. HTTP Port: 42297. gRPC Port: 35615
		== APP == Start echo app (callee) - callee: , Dapr gRPC Port: 35615, Echo App Port: 6000
		
		== APP == Server listening on 127.0.0.1:6000
		
		time="2021-02-01T23:42:48.23973724Z" level=info msg="starting Dapr Runtime -- version 1.0.0-rc.3 -- commit 5763267" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.239757717Z" level=info msg="log level set to: info" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.239963675Z" level=info msg="metrics server started on :42267/" app_id=callee instance=8f85f2f7322e scope=dapr.metrics type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.24041984Z" level=info msg="standalone mode configured" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.24043572Z" level=info msg="app id: callee" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.240576649Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.240924092Z" level=info msg="local service entry announced: callee -> 172.17.0.5:35087" app_id=callee instance=8f85f2f7322e scope=dapr.contrib type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.240970221Z" level=info msg="Initialized name resolution to standalone" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241085548Z" level=info msg="waiting for all outstanding components to be processed" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241141293Z" level=info msg="all outstanding components processed" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.24117037Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241178926Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241258764Z" level=info msg="API gRPC server is running on port 35615" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241401099Z" level=info msg="enabled metrics http middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241411741Z" level=info msg="enabled tracing http middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241442243Z" level=info msg="http server is running on port 42297" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.24145289Z" level=info msg="The request body size parameter is: 4" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241472866Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241479649Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241497245Z" level=info msg="internal gRPC server is running on port 35087" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241504767Z" level=info msg="application protocol: grpc. waiting on port 6000.  This will block until the app is listening on that port." app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.241804747Z" level=info msg="application discovered on port 6000" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.242046169Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.actor type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:48.24206311Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 1.643494ms" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		ℹ️  Updating metadata for app command: ./echo_app callee 6000
		✅  You're up and running! Both Dapr and your app logs will appear here.
		
		== APP == OnInvoke() is called
		
		== APP == Got the message: hello dapr
		
		ℹ️  
		terminated signal received: shutting down
		✅  Exited Dapr successfully
		✅  Exited App successfully
		
	Expected stderr:
	Actual stderr:
		
Step: Run caller
	command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
	return_code: 0
	Expected stdout:
		== APP == Call echo method to callee
		== APP == Received [ack : hello dapr] from callee
	Actual stdout:
		ℹ️  Starting Dapr with id echo_app. HTTP Port: 37349. gRPC Port: 37693
		== APP == Start echo app (caller) - callee: callee, Dapr gRPC Port: 37693, Echo App Port: 6100
		
		== APP == Server listening on 127.0.0.1:6100
		
		time="2021-02-01T23:42:53.317129654Z" level=info msg="starting Dapr Runtime -- version 1.0.0-rc.3 -- commit 5763267" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.317149465Z" level=info msg="log level set to: info" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.317306707Z" level=info msg="metrics server started on :40319/" app_id=echo_app instance=8f85f2f7322e scope=dapr.metrics type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.31795445Z" level=info msg="standalone mode configured" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.317968573Z" level=info msg="app id: echo_app" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318149126Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.31853943Z" level=info msg="local service entry announced: echo_app -> 172.17.0.5:36107" app_id=echo_app instance=8f85f2f7322e scope=dapr.contrib type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318590525Z" level=info msg="Initialized name resolution to standalone" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318661643Z" level=info msg="waiting for all outstanding components to be processed" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318670656Z" level=info msg="all outstanding components processed" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318693262Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318701408Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.318792407Z" level=info msg="API gRPC server is running on port 37693" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319025259Z" level=info msg="enabled metrics http middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319036863Z" level=info msg="enabled tracing http middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319067994Z" level=info msg="http server is running on port 37349" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319076183Z" level=info msg="The request body size parameter is: 4" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319096978Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319104252Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319125375Z" level=info msg="internal gRPC server is running on port 36107" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319133006Z" level=info msg="application protocol: grpc. waiting on port 6100.  This will block until the app is listening on that port." app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319344766Z" level=info msg="application discovered on port 6100" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.31947996Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.actor type=log ver=1.0.0-rc.3
		time="2021-02-01T23:42:53.319495445Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 1.541209ms" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.0.0-rc.3
		ℹ️  Updating metadata for app command: ./echo_app caller 6100 callee
		✅  You're up and running! Both Dapr and your app logs will appear here.
		
		== APP == Connecting to 127.0.0.1:37693...
		
		== APP == Call echo method to callee
		
		== APP == Received [ack : hello dapr] from callee
		
		ℹ️  
		terminated signal received: shutting down
		✅  Exited Dapr successfully
		✅  Exited App successfully
		
	Expected stderr:
	Actual stderr:
		
Step: Shutdown dapr
	command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
	return_code: 0
	Expected stdout:
		✅  app stopped successfully: echo_app
		✅  app stopped successfully: callee
	Actual stdout:
		✅  app stopped successfully: echo_app
		✅  app stopped successfully: callee
		
	Expected stderr:
	Actual stderr:
```