### PR TITLE
Updating to dapr runtime v1.1.0-rc.2

### DIFF
--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -77,6 +77,9 @@ service Dapr {
 
   // Sets value in extended metadata of the sidecar
   rpc SetMetadata (SetMetadataRequest) returns (google.protobuf.Empty) {}
+
+  // Shutdown the sidecar
+  rpc Shutdown (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 
 // InvokeServiceRequest represents the request message for Service invocation.

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
@@ -41,6 +41,7 @@ static const char* Dapr_method_names[] = {
   "/dapr.proto.runtime.v1.Dapr/InvokeActor",
   "/dapr.proto.runtime.v1.Dapr/GetMetadata",
   "/dapr.proto.runtime.v1.Dapr/SetMetadata",
+  "/dapr.proto.runtime.v1.Dapr/Shutdown",
 };
 
 std::unique_ptr< Dapr::Stub> Dapr::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -70,6 +71,7 @@ Dapr::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   , rpcmethod_InvokeActor_(Dapr_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_GetMetadata_(Dapr_method_names[18], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetMetadata_(Dapr_method_names[19], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Shutdown_(Dapr_method_names[20], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status Dapr::Stub::InvokeService(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeServiceRequest& request, ::dapr::proto::common::v1::InvokeResponse* response) {
@@ -392,6 +394,22 @@ void Dapr::Stub::experimental_async::SetMetadata(::grpc::ClientContext* context,
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_SetMetadata_, context, request, false);
 }
 
+::grpc::Status Dapr::Stub::Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Shutdown_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Shutdown_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::AsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_Shutdown_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_Shutdown_, context, request, false);
+}
+
 Dapr::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Dapr_method_names[0],
@@ -493,6 +511,11 @@ Dapr::Service::Service() {
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::SetMetadataRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::SetMetadata), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[20],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::google::protobuf::Empty, ::google::protobuf::Empty>(
+          std::mem_fn(&Dapr::Service::Shutdown), this)));
 }
 
 Dapr::Service::~Service() {
@@ -632,6 +655,13 @@ Dapr::Service::~Service() {
 }
 
 ::grpc::Status Dapr::Service::SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
@@ -205,6 +205,14 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncSetMetadataRaw(context, request, cq));
     }
+    // Shutdown the sidecar
+    virtual ::grpc::Status Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncShutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncShutdownRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncShutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncShutdownRaw(context, request, cq));
+    }
     class experimental_async_interface {
      public:
       virtual ~experimental_async_interface() {}
@@ -248,6 +256,8 @@ class Dapr final {
       virtual void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) = 0;
       // Sets value in extended metadata of the sidecar
       virtual void SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      // Shutdown the sidecar
+      virtual void Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
     };
     virtual class experimental_async_interface* experimental_async() { return nullptr; }
   private:
@@ -291,6 +301,8 @@ class Dapr final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -435,6 +447,13 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncSetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncSetMetadataRaw(context, request, cq));
     }
+    ::grpc::Status Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncShutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncShutdownRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncShutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncShutdownRaw(context, request, cq));
+    }
     class experimental_async final :
       public StubInterface::experimental_async_interface {
      public:
@@ -458,6 +477,7 @@ class Dapr final {
       void InvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response, std::function<void(::grpc::Status)>) override;
       void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) override;
       void SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
      private:
       friend class Stub;
       explicit experimental_async(Stub* stub): stub_(stub) { }
@@ -509,6 +529,8 @@ class Dapr final {
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncShutdownRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_InvokeService_;
     const ::grpc::internal::RpcMethod rpcmethod_GetState_;
     const ::grpc::internal::RpcMethod rpcmethod_GetBulkState_;
@@ -529,6 +551,7 @@ class Dapr final {
     const ::grpc::internal::RpcMethod rpcmethod_InvokeActor_;
     const ::grpc::internal::RpcMethod rpcmethod_GetMetadata_;
     const ::grpc::internal::RpcMethod rpcmethod_SetMetadata_;
+    const ::grpc::internal::RpcMethod rpcmethod_Shutdown_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -576,6 +599,8 @@ class Dapr final {
     virtual ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response);
     // Sets value in extended metadata of the sidecar
     virtual ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response);
+    // Shutdown the sidecar
+    virtual ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_InvokeService : public BaseClass {
@@ -977,7 +1002,27 @@ class Dapr final {
       ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_DeleteState<WithAsyncMethod_DeleteBulkState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<WithAsyncMethod_GetMetadata<WithAsyncMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_Shutdown() {
+      ::grpc::Service::MarkMethodAsync(20);
+    }
+    ~WithAsyncMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestShutdown(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_DeleteState<WithAsyncMethod_DeleteBulkState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<WithAsyncMethod_GetMetadata<WithAsyncMethod_SetMetadata<WithAsyncMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithGenericMethod_InvokeService : public BaseClass {
    private:
@@ -1314,6 +1359,23 @@ class Dapr final {
     }
     // disable synchronous version of this method
     ::grpc::Status SetMetadata(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_Shutdown() {
+      ::grpc::Service::MarkMethodGeneric(20);
+    }
+    ~WithGenericMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1719,6 +1781,26 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_Shutdown() {
+      ::grpc::Service::MarkMethodRaw(20);
+    }
+    ~WithRawMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestShutdown(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_InvokeService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
@@ -2118,9 +2200,29 @@ class Dapr final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetMetadata(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::SetMetadataRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_Shutdown : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_Shutdown() {
+      ::grpc::Service::MarkMethodStreamed(20,
+        new ::grpc::internal::StreamedUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_Shutdown<BaseClass>::StreamedShutdown, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_Shutdown() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedShutdown(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<Service > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace v1

--- a/src/dapr/proto/runtime/v1/dapr.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.pb.cc
@@ -1680,7 +1680,7 @@ void AddDescriptorsImpl() {
       "\005\"C\n\024RegisteredComponents\022\014\n\004name\030\001 \001(\t\022"
       "\014\n\004type\030\002 \001(\t\022\017\n\007version\030\003 \001(\t\"0\n\022SetMet"
       "adataRequest\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t"
-      "2\307\017\n\004Dapr\022d\n\rInvokeService\022+.dapr.proto."
+      "2\205\020\n\004Dapr\022d\n\rInvokeService\022+.dapr.proto."
       "runtime.v1.InvokeServiceRequest\032$.dapr.p"
       "roto.common.v1.InvokeResponse\"\000\022]\n\010GetSt"
       "ate\022&.dapr.proto.runtime.v1.GetStateRequ"
@@ -1729,13 +1729,15 @@ void AddDescriptorsImpl() {
       "\022\026.google.protobuf.Empty\032*.dapr.proto.ru"
       "ntime.v1.GetMetadataResponse\"\000\022R\n\013SetMet"
       "adata\022).dapr.proto.runtime.v1.SetMetadat"
-      "aRequest\032\026.google.protobuf.Empty\"\000Bi\n\nio"
-      ".dapr.v1B\nDaprProtosZ1github.com/dapr/da"
-      "pr/pkg/proto/runtime/v1;runtime\252\002\033Dapr.C"
-      "lient.Autogen.Grpc.v1b\006proto3"
+      "aRequest\032\026.google.protobuf.Empty\"\000\022<\n\010Sh"
+      "utdown\022\026.google.protobuf.Empty\032\026.google."
+      "protobuf.Empty\"\000Bi\n\nio.dapr.v1B\nDaprProt"
+      "osZ1github.com/dapr/dapr/pkg/proto/runti"
+      "me/v1;runtime\252\002\033Dapr.Client.Autogen.Grpc"
+      ".v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 6909);
+      descriptor, 6971);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/dapr.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();


### PR DESCRIPTION
Regenerated protobufs and validated:

```bash
 cpp-sdk % docker exec eager_saha bash -c 'cd /workspaces/cpp-sdk/examples/echo_app && mm.py README.md && echo SUCCESS'
Running shell 'bash -c' with command: `make`
Running shell 'bash -c' with command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
Running shell 'bash -c' with command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
Running shell 'bash -c' with command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
Step: Build example
	command: `make`
	return_code: [32m0[0m
	Expected stdout:
	Actual stdout:
		make: Nothing to be done for 'all'.
		
	Expected stderr:
	Actual stderr:
		
Step: Run callee
	command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
	return_code: [32m0[0m
	Expected stdout:
		== APP == OnInvoke() is called
		== APP == Got the message: hello dapr
	Actual stdout:
		ℹ️  Starting Dapr with id callee. HTTP Port: 44967. gRPC Port: 41403
		== APP == Start echo app (callee) - callee: , Dapr gRPC Port: 41403, Echo App Port: 6000
		
		== APP == Server listening on 127.0.0.1:6000
		
		time="2021-03-31T17:53:53.9226235Z" level=info msg="starting Dapr Runtime -- version 1.1.0-rc.2 -- commit dffe94e" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.922658Z" level=info msg="log level set to: info" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9229189Z" level=info msg="metrics server started on :42813/" app_id=callee instance=8f85f2f7322e scope=dapr.metrics type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9234678Z" level=info msg="standalone mode configured" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9235013Z" level=info msg="app id: callee" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9241137Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9244541Z" level=info msg="local service entry announced: callee -> 172.17.0.5:33499" app_id=callee instance=8f85f2f7322e scope=dapr.contrib type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9244892Z" level=info msg="Initialized name resolution to standalone" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9247015Z" level=info msg="waiting for all outstanding components to be processed" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9247988Z" level=info msg="all outstanding components processed" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9248581Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.924884Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9249573Z" level=info msg="API gRPC server is running on port 41403" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9251595Z" level=info msg="enabled metrics http middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9251829Z" level=info msg="enabled tracing http middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9252018Z" level=info msg="http server is running on port 44967" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9252193Z" level=info msg="The request body size parameter is: 4" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9252527Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9252735Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9253048Z" level=info msg="internal gRPC server is running on port 33499" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9253315Z" level=info msg="application protocol: grpc. waiting on port 6000.  This will block until the app is listening on that port." app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9256415Z" level=info msg="application discovered on port 6000" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9260067Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=callee instance=8f85f2f7322e scope=dapr.runtime.actor type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:53.9260476Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 2.5826ms" app_id=callee instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		ℹ️  Updating metadata for app command: ./echo_app callee 6000
		✅  You're up and running! Both Dapr and your app logs will appear here.
		
		[32m== APP == OnInvoke() is called[0m
		
		[32m== APP == Got the message: hello dapr[0m
		
		ℹ️  
		terminated signal received: shutting down
		✅  Exited Dapr successfully
		✅  Exited App successfully
		
	Expected stderr:
	Actual stderr:
		
Step: Run caller
	command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
	return_code: [32m0[0m
	Expected stdout:
		== APP == Call echo method to callee
		== APP == Received [ack : hello dapr] from callee
	Actual stdout:
		ℹ️  Starting Dapr with id echo_app. HTTP Port: 33125. gRPC Port: 35665
		== APP == Start echo app (caller) - callee: callee, Dapr gRPC Port: 35665, Echo App Port: 6100
		
		== APP == Server listening on 127.0.0.1:6100
		
		time="2021-03-31T17:53:58.9519267Z" level=info msg="starting Dapr Runtime -- version 1.1.0-rc.2 -- commit dffe94e" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.951972Z" level=info msg="log level set to: info" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9522776Z" level=info msg="metrics server started on :41709/" app_id=echo_app instance=8f85f2f7322e scope=dapr.metrics type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9529075Z" level=info msg="standalone mode configured" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9529373Z" level=info msg="app id: echo_app" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9538419Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9544281Z" level=info msg="local service entry announced: echo_app -> 172.17.0.5:39915" app_id=echo_app instance=8f85f2f7322e scope=dapr.contrib type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9546743Z" level=info msg="Initialized name resolution to standalone" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9548899Z" level=info msg="waiting for all outstanding components to be processed" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9549268Z" level=info msg="all outstanding components processed" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9549829Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9550166Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.api type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9551059Z" level=info msg="API gRPC server is running on port 35665" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9553773Z" level=info msg="enabled metrics http middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9554094Z" level=info msg="enabled tracing http middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.http type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9554591Z" level=info msg="http server is running on port 33125" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9555138Z" level=info msg="The request body size parameter is: 4" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9555844Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9556092Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.grpc.internal type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9556448Z" level=info msg="internal gRPC server is running on port 39915" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9556744Z" level=info msg="application protocol: grpc. waiting on port 6100.  This will block until the app is listening on that port." app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9562285Z" level=info msg="application discovered on port 6100" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.95667Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime.actor type=log ver=1.1.0-rc.2
		time="2021-03-31T17:53:58.9568296Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 3.8371999999999997ms" app_id=echo_app instance=8f85f2f7322e scope=dapr.runtime type=log ver=1.1.0-rc.2
		ℹ️  Updating metadata for app command: ./echo_app caller 6100 callee
		✅  You're up and running! Both Dapr and your app logs will appear here.
		
		== APP == Connecting to 127.0.0.1:35665...
		
		[32m== APP == Call echo method to callee[0m
		
		[32m== APP == Received [ack : hello dapr] from callee[0m
		
		ℹ️  
		terminated signal received: shutting down
		✅  Exited Dapr successfully
		✅  Exited App successfully
		
	Expected stderr:
	Actual stderr:
		
Step: Shutdown dapr
	command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
	return_code: [32m0[0m
	Expected stdout:
		✅  app stopped successfully: echo_app
		✅  app stopped successfully: callee
	Actual stdout:
		[32m✅  app stopped successfully: echo_app[0m
		[32m✅  app stopped successfully: callee[0m
		
	Expected stderr:
	Actual stderr:
		

SUCCESS

```
