### PR TITLE
Updating to dapr runtime v1.5.0-rc.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update \
     && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
     && apt-get update \
-    && apt-get install -y docker-ce-cli \
+    && apt-get install -y docker-ce-cli python3 python3-pip \
+    && pip3 install mechanical-markdown \
     #
     # [Optional] Update UID/GID if needed
     && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ Alpha quality.
     ```bash
     make all
     ```
+
+### Run the example validation
+
+1. Make sure that you enable vscode remote container
+2. Run the example validation
+    ```bash
+    cd examples/echo_app/ && mm.py README.md && echo SUCCESS
+    ```

--- a/dapr/proto/common/v1/common.proto
+++ b/dapr/proto/common/v1/common.proto
@@ -24,6 +24,7 @@ option go_package = "github.com/dapr/dapr/pkg/proto/common/v1;common";
 message HTTPExtension {
   // Type of HTTP 1.1 Methods
   // RFC 7231: https://tools.ietf.org/html/rfc7231#page-24
+  // RFC 5789: https://datatracker.ietf.org/doc/html/rfc5789
   enum Verb {
     NONE = 0;
     GET = 1;
@@ -34,6 +35,7 @@ message HTTPExtension {
     CONNECT = 6;
     OPTIONS = 7;
     TRACE = 8;
+    PATCH = 9;
   }
 
   // Required. HTTP verb.
@@ -122,4 +124,20 @@ message StateOptions {
 
   StateConcurrency concurrency = 1;
   StateConsistency consistency = 2;
+}
+
+
+// ConfigurationItem represents all the configuration with its name(key).
+message ConfigurationItem {
+  // Required. The name of configuration item
+  string key = 1;
+
+  // Required. The value of configuration item.
+  string value = 2;
+
+  // Version is response only and cannot be fetched. Store is not expected to keep all versions available
+  string version = 3;
+
+  // the metadata which will be passed to/from configuration store component.
+  map<string,string> metadata = 4;
 }

--- a/dapr/proto/runtime/v1/appcallback.proto
+++ b/dapr/proto/runtime/v1/appcallback.proto
@@ -70,6 +70,10 @@ message TopicEventRequest {
 
   // The name of the pubsub the publisher sent to.
   string pubsub_name = 8;
+
+  // The matching path from TopicSubscription/routes (if specified) for this event.
+  // This value is used by OnTopicEvent to "switch" inside the handler.
+  string path = 9;
 }
 
 // TopicEventResponse is response from app on published message
@@ -144,6 +148,30 @@ message TopicSubscription {
 
   // The optional properties used for this topic's subscription e.g. session id
   map<string,string> metadata = 3;
+
+  // The optional routing rules to match against. In the gRPC interface, OnTopicEvent
+  // is still invoked but the matching path is sent in the TopicEventRequest.
+  TopicRoutes routes = 5;
+}
+
+message TopicRoutes {
+  // The list of rules for this topic.
+  repeated TopicRule rules = 1;
+
+  // The default path for this topic.
+  string default = 2;
+}
+
+message TopicRule {
+  // The optional CEL expression used to match the event.
+	// If the match is not specified, then the route is considered
+	// the default.
+  string match = 1;
+
+  // The path used to identify matches for this subscription.
+  // This value is passed in TopicEventRequest and used by OnTopicEvent to "switch"
+  // inside the handler.
+  string path = 2;
 }
 
 // ListInputBindingsResponse is the message including the list of input bindings.

--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -30,6 +30,9 @@ service Dapr {
   // Saves the state for a specific key.
   rpc SaveState(SaveStateRequest) returns (google.protobuf.Empty) {}
 
+  // Queries the state.
+  rpc QueryStateAlpha1(QueryStateRequest) returns (QueryStateResponse) {}
+
   // Deletes the state for a specific key.
   rpc DeleteState(DeleteStateRequest) returns (google.protobuf.Empty) {}
 
@@ -71,6 +74,12 @@ service Dapr {
 
   // InvokeActor calls a method on an actor.
   rpc InvokeActor (InvokeActorRequest) returns (InvokeActorResponse) {}
+
+  // GetConfiguration gets configuration from configuration store.
+  rpc GetConfigurationAlpha1(GetConfigurationRequest) returns (GetConfigurationResponse) {}
+
+  // SubscribeConfiguration gets configuration from configuration store and subscribe the updates event by grpc stream
+  rpc SubscribeConfigurationAlpha1(SubscribeConfigurationRequest) returns (stream SubscribeConfigurationResponse) {}
 
   // Gets metadata of the sidecar
   rpc GetMetadata (google.protobuf.Empty) returns (GetMetadataResponse) {}
@@ -198,6 +207,45 @@ message SaveStateRequest {
   repeated common.v1.StateItem states = 2;
 }
 
+// QueryStateRequest is the message to query state store.
+message QueryStateRequest {
+  // The name of state store.
+  string store_name = 1;
+
+  // The query in JSON format.
+  string query = 2;
+
+  // The metadata which will be sent to state store components.
+  map<string,string> metadata = 3;
+}
+
+message QueryStateItem {
+  // The object key.
+  string key = 1;
+
+  // The object value.
+  bytes  data = 2;
+
+  // The entity tag which represents the specific version of data.
+  // ETag format is defined by the corresponding data store.
+  string etag = 3;
+
+  // The error message indicating an error in processing of the query result.
+  string error = 4;
+}
+
+// QueryStateResponse is the response conveying the query results.
+message QueryStateResponse {
+  // An array of query results.
+  repeated QueryStateItem results = 1;
+
+  // Pagination token.
+  string token = 2;
+
+  // The metadata which will be sent to app.
+  map<string,string> metadata = 3;
+}
+
 // PublishEventRequest is the message to publish event data to pubsub topic
 message PublishEventRequest {
   // The name of the pubsub component
@@ -319,6 +367,7 @@ message RegisterActorTimerRequest {
   string period = 5;
   string callback = 6;
   bytes  data = 7;
+  string ttl = 8;
 }
 
 // UnregisterActorTimerRequest is the message to unregister an actor timer
@@ -336,6 +385,7 @@ message RegisterActorReminderRequest {
   string due_time = 4;
   string period = 5;
   bytes  data = 6;
+  string ttl = 7;
 }
 
 // UnregisterActorReminderRequest is the message to unregister an actor reminder.
@@ -407,3 +457,43 @@ message SetMetadataRequest {
   string key = 1;
   string value = 2;
 }
+
+// GetConfigurationRequest is the message to get a list of key-value configuration from specified configuration store.
+message GetConfigurationRequest {
+  // Required. The name of configuration store.
+  string store_name = 1;
+
+  // Optional. The key of the configuration item to fetch.
+  // If set, only query for the specified configuration items.
+  // Empty list means fetch all.
+  repeated string keys = 2;
+
+  // Optional. The metadata which will be sent to configuration store components.
+  map<string,string> metadata = 3;
+}
+
+// GetConfigurationResponse is the response conveying the list of configuration values.
+// It should be the FULL configuration of specified application which contains all of its configuration items.
+message GetConfigurationResponse {
+  repeated common.v1.ConfigurationItem items = 1;
+}
+
+// SubscribeConfigurationRequest is the message to get a list of key-value configuration from specified configuration store.
+message SubscribeConfigurationRequest {
+  // The name of configuration store.
+  string store_name = 1;
+
+  // Optional. The key of the configuration item to fetch.
+  // If set, only query for the specified configuration items.
+  // Empty list means fetch all.
+  repeated string keys = 2;
+
+  // The metadata which will be sent to configuration store components.
+  map<string,string> metadata = 3;
+}
+
+message SubscribeConfigurationResponse {
+  // The list of items containing configuration values
+  repeated common.v1.ConfigurationItem items = 1;
+}
+

--- a/src/dapr/proto/common/v1/common.pb.cc
+++ b/src/dapr/proto/common/v1/common.pb.cc
@@ -20,6 +20,7 @@
 // @@protoc_insertion_point(includes)
 
 namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_ConfigurationItem_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_Etag;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_HTTPExtension;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_StateItem_MetadataEntry_DoNotUse;
@@ -67,6 +68,16 @@ class StateOptionsDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<StateOptions>
       _instance;
 } _StateOptions_default_instance_;
+class ConfigurationItem_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ConfigurationItem_MetadataEntry_DoNotUse>
+      _instance;
+} _ConfigurationItem_MetadataEntry_DoNotUse_default_instance_;
+class ConfigurationItemDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ConfigurationItem>
+      _instance;
+} _ConfigurationItem_default_instance_;
 }  // namespace v1
 }  // namespace common
 }  // namespace proto
@@ -175,6 +186,34 @@ static void InitDefaultsStateOptions() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_StateOptions =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsStateOptions}, {}};
 
+static void InitDefaultsConfigurationItem_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::common::v1::_ConfigurationItem_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ConfigurationItem_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsConfigurationItem_MetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsConfigurationItem() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::common::v1::_ConfigurationItem_default_instance_;
+    new (ptr) ::dapr::proto::common::v1::ConfigurationItem();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::common::v1::ConfigurationItem::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_ConfigurationItem =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsConfigurationItem}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_ConfigurationItem_MetadataEntry_DoNotUse.base,}};
+
 void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_HTTPExtension.base);
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeRequest.base);
@@ -183,9 +222,11 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_StateItem.base);
   ::google::protobuf::internal::InitSCC(&scc_info_Etag.base);
   ::google::protobuf::internal::InitSCC(&scc_info_StateOptions.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ConfigurationItem_MetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ConfigurationItem.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[7];
+::google::protobuf::Metadata file_level_metadata[9];
 const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[3];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
@@ -244,6 +285,24 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::StateOptions, concurrency_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::StateOptions, consistency_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem, version_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::common::v1::ConfigurationItem, metadata_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::common::v1::HTTPExtension)},
@@ -253,6 +312,8 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 32, -1, sizeof(::dapr::proto::common::v1::StateItem)},
   { 42, -1, sizeof(::dapr::proto::common::v1::Etag)},
   { 48, -1, sizeof(::dapr::proto::common::v1::StateOptions)},
+  { 55, 62, sizeof(::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse)},
+  { 64, -1, sizeof(::dapr::proto::common::v1::ConfigurationItem)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -263,6 +324,8 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_StateItem_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_Etag_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_StateOptions_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_ConfigurationItem_MetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::common::v1::_ConfigurationItem_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -280,7 +343,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 7);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 9);
 }
 
 void AddDescriptorsImpl() {
@@ -288,39 +351,44 @@ void AddDescriptorsImpl() {
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n!dapr/proto/common/v1/common.proto\022\024dap"
       "r.proto.common.v1\032\031google/protobuf/any.p"
-      "roto\"\305\001\n\rHTTPExtension\0226\n\004verb\030\001 \001(\0162(.d"
+      "roto\"\320\001\n\rHTTPExtension\0226\n\004verb\030\001 \001(\0162(.d"
       "apr.proto.common.v1.HTTPExtension.Verb\022\023"
-      "\n\013querystring\030\002 \001(\t\"g\n\004Verb\022\010\n\004NONE\020\000\022\007\n"
+      "\n\013querystring\030\002 \001(\t\"r\n\004Verb\022\010\n\004NONE\020\000\022\007\n"
       "\003GET\020\001\022\010\n\004HEAD\020\002\022\010\n\004POST\020\003\022\007\n\003PUT\020\004\022\n\n\006D"
       "ELETE\020\005\022\013\n\007CONNECT\020\006\022\013\n\007OPTIONS\020\007\022\t\n\005TRA"
-      "CE\020\010\"\226\001\n\rInvokeRequest\022\016\n\006method\030\001 \001(\t\022\""
-      "\n\004data\030\002 \001(\0132\024.google.protobuf.Any\022\024\n\014co"
-      "ntent_type\030\003 \001(\t\022;\n\016http_extension\030\004 \001(\013"
-      "2#.dapr.proto.common.v1.HTTPExtension\"J\n"
-      "\016InvokeResponse\022\"\n\004data\030\001 \001(\0132\024.google.p"
-      "rotobuf.Any\022\024\n\014content_type\030\002 \001(\t\"\370\001\n\tSt"
-      "ateItem\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014\022(\n\004e"
-      "tag\030\003 \001(\0132\032.dapr.proto.common.v1.Etag\022\?\n"
-      "\010metadata\030\004 \003(\0132-.dapr.proto.common.v1.S"
-      "tateItem.MetadataEntry\0223\n\007options\030\005 \001(\0132"
-      "\".dapr.proto.common.v1.StateOptions\032/\n\rM"
-      "etadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t"
-      ":\0028\001\"\025\n\004Etag\022\r\n\005value\030\001 \001(\t\"\357\002\n\014StateOpt"
-      "ions\022H\n\013concurrency\030\001 \001(\01623.dapr.proto.c"
-      "ommon.v1.StateOptions.StateConcurrency\022H"
-      "\n\013consistency\030\002 \001(\01623.dapr.proto.common."
-      "v1.StateOptions.StateConsistency\"h\n\020Stat"
-      "eConcurrency\022\033\n\027CONCURRENCY_UNSPECIFIED\020"
-      "\000\022\033\n\027CONCURRENCY_FIRST_WRITE\020\001\022\032\n\026CONCUR"
-      "RENCY_LAST_WRITE\020\002\"a\n\020StateConsistency\022\033"
-      "\n\027CONSISTENCY_UNSPECIFIED\020\000\022\030\n\024CONSISTEN"
-      "CY_EVENTUAL\020\001\022\026\n\022CONSISTENCY_STRONG\020\002Bi\n"
+      "CE\020\010\022\t\n\005PATCH\020\t\"\226\001\n\rInvokeRequest\022\016\n\006met"
+      "hod\030\001 \001(\t\022\"\n\004data\030\002 \001(\0132\024.google.protobu"
+      "f.Any\022\024\n\014content_type\030\003 \001(\t\022;\n\016http_exte"
+      "nsion\030\004 \001(\0132#.dapr.proto.common.v1.HTTPE"
+      "xtension\"J\n\016InvokeResponse\022\"\n\004data\030\001 \001(\013"
+      "2\024.google.protobuf.Any\022\024\n\014content_type\030\002"
+      " \001(\t\"\370\001\n\tStateItem\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+      "\030\002 \001(\014\022(\n\004etag\030\003 \001(\0132\032.dapr.proto.common"
+      ".v1.Etag\022\?\n\010metadata\030\004 \003(\0132-.dapr.proto."
+      "common.v1.StateItem.MetadataEntry\0223\n\007opt"
+      "ions\030\005 \001(\0132\".dapr.proto.common.v1.StateO"
+      "ptions\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005"
+      "value\030\002 \001(\t:\0028\001\"\025\n\004Etag\022\r\n\005value\030\001 \001(\t\"\357"
+      "\002\n\014StateOptions\022H\n\013concurrency\030\001 \001(\01623.d"
+      "apr.proto.common.v1.StateOptions.StateCo"
+      "ncurrency\022H\n\013consistency\030\002 \001(\01623.dapr.pr"
+      "oto.common.v1.StateOptions.StateConsiste"
+      "ncy\"h\n\020StateConcurrency\022\033\n\027CONCURRENCY_U"
+      "NSPECIFIED\020\000\022\033\n\027CONCURRENCY_FIRST_WRITE\020"
+      "\001\022\032\n\026CONCURRENCY_LAST_WRITE\020\002\"a\n\020StateCo"
+      "nsistency\022\033\n\027CONSISTENCY_UNSPECIFIED\020\000\022\030"
+      "\n\024CONSISTENCY_EVENTUAL\020\001\022\026\n\022CONSISTENCY_"
+      "STRONG\020\002\"\272\001\n\021ConfigurationItem\022\013\n\003key\030\001 "
+      "\001(\t\022\r\n\005value\030\002 \001(\t\022\017\n\007version\030\003 \001(\t\022G\n\010m"
+      "etadata\030\004 \003(\01325.dapr.proto.common.v1.Con"
+      "figurationItem.MetadataEntry\032/\n\rMetadata"
+      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001Bi\n"
       "\nio.dapr.v1B\014CommonProtosZ/github.com/da"
       "pr/dapr/pkg/proto/common/v1;common\252\002\033Dap"
       "r.Client.Autogen.Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 1272);
+      descriptor, 1472);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/common/v1/common.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();
@@ -356,6 +424,7 @@ bool HTTPExtension_Verb_IsValid(int value) {
     case 6:
     case 7:
     case 8:
+    case 9:
       return true;
     default:
       return false;
@@ -372,6 +441,7 @@ const HTTPExtension_Verb HTTPExtension::DELETE;
 const HTTPExtension_Verb HTTPExtension::CONNECT;
 const HTTPExtension_Verb HTTPExtension::OPTIONS;
 const HTTPExtension_Verb HTTPExtension::TRACE;
+const HTTPExtension_Verb HTTPExtension::PATCH;
 const HTTPExtension_Verb HTTPExtension::Verb_MIN;
 const HTTPExtension_Verb HTTPExtension::Verb_MAX;
 const int HTTPExtension::Verb_ARRAYSIZE;
@@ -2484,6 +2554,537 @@ void StateOptions::InternalSwap(StateOptions* other) {
 }
 
 
+// ===================================================================
+
+ConfigurationItem_MetadataEntry_DoNotUse::ConfigurationItem_MetadataEntry_DoNotUse() {}
+ConfigurationItem_MetadataEntry_DoNotUse::ConfigurationItem_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void ConfigurationItem_MetadataEntry_DoNotUse::MergeFrom(const ConfigurationItem_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata ConfigurationItem_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[7];
+}
+void ConfigurationItem_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void ConfigurationItem::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ConfigurationItem::kKeyFieldNumber;
+const int ConfigurationItem::kValueFieldNumber;
+const int ConfigurationItem::kVersionFieldNumber;
+const int ConfigurationItem::kMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ConfigurationItem::ConfigurationItem()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_ConfigurationItem.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.common.v1.ConfigurationItem)
+}
+ConfigurationItem::ConfigurationItem(const ConfigurationItem& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.key().size() > 0) {
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.value().size() > 0) {
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+  version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.version().size() > 0) {
+    version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.version_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.common.v1.ConfigurationItem)
+}
+
+void ConfigurationItem::SharedCtor() {
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+ConfigurationItem::~ConfigurationItem() {
+  // @@protoc_insertion_point(destructor:dapr.proto.common.v1.ConfigurationItem)
+  SharedDtor();
+}
+
+void ConfigurationItem::SharedDtor() {
+  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ConfigurationItem::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ConfigurationItem::descriptor() {
+  ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ConfigurationItem& ConfigurationItem::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_ConfigurationItem.base);
+  return *internal_default_instance();
+}
+
+
+void ConfigurationItem::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.common.v1.ConfigurationItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  metadata_.Clear();
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool ConfigurationItem::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.common.v1.ConfigurationItem)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string key = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_key()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->key().data(), static_cast<int>(this->key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.ConfigurationItem.key"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string value = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_value()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->value().data(), static_cast<int>(this->value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.ConfigurationItem.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string version = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_version()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->version().data(), static_cast<int>(this->version().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.ConfigurationItem.version"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> metadata = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          ConfigurationItem_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              ConfigurationItem_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.common.v1.ConfigurationItem)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.common.v1.ConfigurationItem)
+  return false;
+#undef DO_
+}
+
+void ConfigurationItem::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.common.v1.ConfigurationItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.key");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->key(), output);
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.value");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->value(), output);
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->version().data(), static_cast<int>(this->version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.version");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      3, this->version(), output);
+  }
+
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<ConfigurationItem_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<ConfigurationItem_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            4, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.common.v1.ConfigurationItem)
+}
+
+::google::protobuf::uint8* ConfigurationItem::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.common.v1.ConfigurationItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.key");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->key(), target);
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->value().data(), static_cast<int>(this->value().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.value");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->value(), target);
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->version().data(), static_cast<int>(this->version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.common.v1.ConfigurationItem.version");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        3, this->version(), target);
+  }
+
+  // map<string, string> metadata = 4;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.common.v1.ConfigurationItem.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<ConfigurationItem_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<ConfigurationItem_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       4, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.common.v1.ConfigurationItem)
+  return target;
+}
+
+size_t ConfigurationItem::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.common.v1.ConfigurationItem)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // map<string, string> metadata = 4;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<ConfigurationItem_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->key());
+  }
+
+  // string value = 2;
+  if (this->value().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->value());
+  }
+
+  // string version = 3;
+  if (this->version().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->version());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ConfigurationItem::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.common.v1.ConfigurationItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ConfigurationItem* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ConfigurationItem>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.common.v1.ConfigurationItem)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.common.v1.ConfigurationItem)
+    MergeFrom(*source);
+  }
+}
+
+void ConfigurationItem::MergeFrom(const ConfigurationItem& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.common.v1.ConfigurationItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  metadata_.MergeFrom(from.metadata_);
+  if (from.key().size() > 0) {
+
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  if (from.value().size() > 0) {
+
+    value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.value_);
+  }
+  if (from.version().size() > 0) {
+
+    version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.version_);
+  }
+}
+
+void ConfigurationItem::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.common.v1.ConfigurationItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ConfigurationItem::CopyFrom(const ConfigurationItem& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.common.v1.ConfigurationItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ConfigurationItem::IsInitialized() const {
+  return true;
+}
+
+void ConfigurationItem::Swap(ConfigurationItem* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ConfigurationItem::InternalSwap(ConfigurationItem* other) {
+  using std::swap;
+  metadata_.Swap(&other->metadata_);
+  key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  value_.Swap(&other->value_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  version_.Swap(&other->version_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ConfigurationItem::GetMetadata() const {
+  protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace v1
 }  // namespace common
@@ -2511,6 +3112,12 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::Etag* A
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::StateOptions* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::StateOptions >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::common::v1::StateOptions >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::common::v1::ConfigurationItem* Arena::CreateMaybeMessage< ::dapr::proto::common::v1::ConfigurationItem >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::common::v1::ConfigurationItem >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/dapr/proto/common/v1/common.pb.h
+++ b/src/dapr/proto/common/v1/common.pb.h
@@ -43,7 +43,7 @@ namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[7];
+  static const ::google::protobuf::internal::ParseTable schema[9];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -54,6 +54,12 @@ namespace dapr {
 namespace proto {
 namespace common {
 namespace v1 {
+class ConfigurationItem;
+class ConfigurationItemDefaultTypeInternal;
+extern ConfigurationItemDefaultTypeInternal _ConfigurationItem_default_instance_;
+class ConfigurationItem_MetadataEntry_DoNotUse;
+class ConfigurationItem_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern ConfigurationItem_MetadataEntry_DoNotUseDefaultTypeInternal _ConfigurationItem_MetadataEntry_DoNotUse_default_instance_;
 class Etag;
 class EtagDefaultTypeInternal;
 extern EtagDefaultTypeInternal _Etag_default_instance_;
@@ -81,6 +87,8 @@ extern StateOptionsDefaultTypeInternal _StateOptions_default_instance_;
 }  // namespace dapr
 namespace google {
 namespace protobuf {
+template<> ::dapr::proto::common::v1::ConfigurationItem* Arena::CreateMaybeMessage<::dapr::proto::common::v1::ConfigurationItem>(Arena*);
+template<> ::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::common::v1::ConfigurationItem_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::common::v1::Etag* Arena::CreateMaybeMessage<::dapr::proto::common::v1::Etag>(Arena*);
 template<> ::dapr::proto::common::v1::HTTPExtension* Arena::CreateMaybeMessage<::dapr::proto::common::v1::HTTPExtension>(Arena*);
 template<> ::dapr::proto::common::v1::InvokeRequest* Arena::CreateMaybeMessage<::dapr::proto::common::v1::InvokeRequest>(Arena*);
@@ -105,12 +113,13 @@ enum HTTPExtension_Verb {
   HTTPExtension_Verb_CONNECT = 6,
   HTTPExtension_Verb_OPTIONS = 7,
   HTTPExtension_Verb_TRACE = 8,
+  HTTPExtension_Verb_PATCH = 9,
   HTTPExtension_Verb_HTTPExtension_Verb_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
   HTTPExtension_Verb_HTTPExtension_Verb_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
 };
 bool HTTPExtension_Verb_IsValid(int value);
 const HTTPExtension_Verb HTTPExtension_Verb_Verb_MIN = HTTPExtension_Verb_NONE;
-const HTTPExtension_Verb HTTPExtension_Verb_Verb_MAX = HTTPExtension_Verb_TRACE;
+const HTTPExtension_Verb HTTPExtension_Verb_Verb_MAX = HTTPExtension_Verb_PATCH;
 const int HTTPExtension_Verb_Verb_ARRAYSIZE = HTTPExtension_Verb_Verb_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* HTTPExtension_Verb_descriptor();
@@ -273,6 +282,8 @@ class HTTPExtension : public ::google::protobuf::Message /* @@protoc_insertion_p
     HTTPExtension_Verb_OPTIONS;
   static const Verb TRACE =
     HTTPExtension_Verb_TRACE;
+  static const Verb PATCH =
+    HTTPExtension_Verb_PATCH;
   static inline bool Verb_IsValid(int value) {
     return HTTPExtension_Verb_IsValid(value);
   }
@@ -1067,6 +1078,184 @@ class StateOptions : public ::google::protobuf::Message /* @@protoc_insertion_po
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::TableStruct;
 };
+// -------------------------------------------------------------------
+
+class ConfigurationItem_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<ConfigurationItem_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<ConfigurationItem_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  ConfigurationItem_MetadataEntry_DoNotUse();
+  ConfigurationItem_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const ConfigurationItem_MetadataEntry_DoNotUse& other);
+  static const ConfigurationItem_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const ConfigurationItem_MetadataEntry_DoNotUse*>(&_ConfigurationItem_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class ConfigurationItem : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.common.v1.ConfigurationItem) */ {
+ public:
+  ConfigurationItem();
+  virtual ~ConfigurationItem();
+
+  ConfigurationItem(const ConfigurationItem& from);
+
+  inline ConfigurationItem& operator=(const ConfigurationItem& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ConfigurationItem(ConfigurationItem&& from) noexcept
+    : ConfigurationItem() {
+    *this = ::std::move(from);
+  }
+
+  inline ConfigurationItem& operator=(ConfigurationItem&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ConfigurationItem& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ConfigurationItem* internal_default_instance() {
+    return reinterpret_cast<const ConfigurationItem*>(
+               &_ConfigurationItem_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  void Swap(ConfigurationItem* other);
+  friend void swap(ConfigurationItem& a, ConfigurationItem& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ConfigurationItem* New() const final {
+    return CreateMaybeMessage<ConfigurationItem>(NULL);
+  }
+
+  ConfigurationItem* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ConfigurationItem>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ConfigurationItem& from);
+  void MergeFrom(const ConfigurationItem& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ConfigurationItem* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // map<string, string> metadata = 4;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 4;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
+
+  // string key = 1;
+  void clear_key();
+  static const int kKeyFieldNumber = 1;
+  const ::std::string& key() const;
+  void set_key(const ::std::string& value);
+  #if LANG_CXX11
+  void set_key(::std::string&& value);
+  #endif
+  void set_key(const char* value);
+  void set_key(const char* value, size_t size);
+  ::std::string* mutable_key();
+  ::std::string* release_key();
+  void set_allocated_key(::std::string* key);
+
+  // string value = 2;
+  void clear_value();
+  static const int kValueFieldNumber = 2;
+  const ::std::string& value() const;
+  void set_value(const ::std::string& value);
+  #if LANG_CXX11
+  void set_value(::std::string&& value);
+  #endif
+  void set_value(const char* value);
+  void set_value(const char* value, size_t size);
+  ::std::string* mutable_value();
+  ::std::string* release_value();
+  void set_allocated_value(::std::string* value);
+
+  // string version = 3;
+  void clear_version();
+  static const int kVersionFieldNumber = 3;
+  const ::std::string& version() const;
+  void set_version(const ::std::string& value);
+  #if LANG_CXX11
+  void set_version(::std::string&& value);
+  #endif
+  void set_version(const char* value);
+  void set_version(const char* value, size_t size);
+  ::std::string* mutable_version();
+  ::std::string* release_version();
+  void set_allocated_version(::std::string* version);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.common.v1.ConfigurationItem)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      ConfigurationItem_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
+  ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr value_;
+  ::google::protobuf::internal::ArenaStringPtr version_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::TableStruct;
+};
 // ===================================================================
 
 
@@ -1789,9 +1978,196 @@ inline void StateOptions::set_consistency(::dapr::proto::common::v1::StateOption
   // @@protoc_insertion_point(field_set:dapr.proto.common.v1.StateOptions.consistency)
 }
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// ConfigurationItem
+
+// string key = 1;
+inline void ConfigurationItem::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ConfigurationItem::key() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.common.v1.ConfigurationItem.key)
+  return key_.GetNoArena();
+}
+inline void ConfigurationItem::set_key(const ::std::string& value) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.common.v1.ConfigurationItem.key)
+}
+#if LANG_CXX11
+inline void ConfigurationItem::set_key(::std::string&& value) {
+  
+  key_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.common.v1.ConfigurationItem.key)
+}
+#endif
+inline void ConfigurationItem::set_key(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.common.v1.ConfigurationItem.key)
+}
+inline void ConfigurationItem::set_key(const char* value, size_t size) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.common.v1.ConfigurationItem.key)
+}
+inline ::std::string* ConfigurationItem::mutable_key() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.ConfigurationItem.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ConfigurationItem::release_key() {
+  // @@protoc_insertion_point(field_release:dapr.proto.common.v1.ConfigurationItem.key)
+  
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ConfigurationItem::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    
+  } else {
+    
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.ConfigurationItem.key)
+}
+
+// string value = 2;
+inline void ConfigurationItem::clear_value() {
+  value_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ConfigurationItem::value() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.common.v1.ConfigurationItem.value)
+  return value_.GetNoArena();
+}
+inline void ConfigurationItem::set_value(const ::std::string& value) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.common.v1.ConfigurationItem.value)
+}
+#if LANG_CXX11
+inline void ConfigurationItem::set_value(::std::string&& value) {
+  
+  value_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.common.v1.ConfigurationItem.value)
+}
+#endif
+inline void ConfigurationItem::set_value(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.common.v1.ConfigurationItem.value)
+}
+inline void ConfigurationItem::set_value(const char* value, size_t size) {
+  
+  value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.common.v1.ConfigurationItem.value)
+}
+inline ::std::string* ConfigurationItem::mutable_value() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.ConfigurationItem.value)
+  return value_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ConfigurationItem::release_value() {
+  // @@protoc_insertion_point(field_release:dapr.proto.common.v1.ConfigurationItem.value)
+  
+  return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ConfigurationItem::set_allocated_value(::std::string* value) {
+  if (value != NULL) {
+    
+  } else {
+    
+  }
+  value_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.ConfigurationItem.value)
+}
+
+// string version = 3;
+inline void ConfigurationItem::clear_version() {
+  version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ConfigurationItem::version() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.common.v1.ConfigurationItem.version)
+  return version_.GetNoArena();
+}
+inline void ConfigurationItem::set_version(const ::std::string& value) {
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.common.v1.ConfigurationItem.version)
+}
+#if LANG_CXX11
+inline void ConfigurationItem::set_version(::std::string&& value) {
+  
+  version_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.common.v1.ConfigurationItem.version)
+}
+#endif
+inline void ConfigurationItem::set_version(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.common.v1.ConfigurationItem.version)
+}
+inline void ConfigurationItem::set_version(const char* value, size_t size) {
+  
+  version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.common.v1.ConfigurationItem.version)
+}
+inline ::std::string* ConfigurationItem::mutable_version() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.common.v1.ConfigurationItem.version)
+  return version_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ConfigurationItem::release_version() {
+  // @@protoc_insertion_point(field_release:dapr.proto.common.v1.ConfigurationItem.version)
+  
+  return version_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ConfigurationItem::set_allocated_version(::std::string* version) {
+  if (version != NULL) {
+    
+  } else {
+    
+  }
+  version_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), version);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.common.v1.ConfigurationItem.version)
+}
+
+// map<string, string> metadata = 4;
+inline int ConfigurationItem::metadata_size() const {
+  return metadata_.size();
+}
+inline void ConfigurationItem::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+ConfigurationItem::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.common.v1.ConfigurationItem.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+ConfigurationItem::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.common.v1.ConfigurationItem.metadata)
+  return metadata_.MutableMap();
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/dapr/proto/runtime/v1/appcallback.pb.cc
+++ b/src/dapr/proto/runtime/v1/appcallback.pb.cc
@@ -24,8 +24,10 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2ep
 }  // namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto
 namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto {
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_BindingEventRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_TopicRule;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_TopicSubscription_MetadataEntry_DoNotUse;
-extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_TopicSubscription;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_TopicRoutes;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto ::google::protobuf::internal::SCCInfo<2> scc_info_TopicSubscription;
 }  // namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto
 namespace dapr {
 namespace proto {
@@ -71,6 +73,16 @@ class TopicSubscriptionDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<TopicSubscription>
       _instance;
 } _TopicSubscription_default_instance_;
+class TopicRoutesDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<TopicRoutes>
+      _instance;
+} _TopicRoutes_default_instance_;
+class TopicRuleDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<TopicRule>
+      _instance;
+} _TopicRule_default_instance_;
 class ListInputBindingsResponseDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<ListInputBindingsResponse>
@@ -191,9 +203,39 @@ static void InitDefaultsTopicSubscription() {
   ::dapr::proto::runtime::v1::TopicSubscription::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<1> scc_info_TopicSubscription =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsTopicSubscription}, {
-      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicSubscription_MetadataEntry_DoNotUse.base,}};
+::google::protobuf::internal::SCCInfo<2> scc_info_TopicSubscription =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 2, InitDefaultsTopicSubscription}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicSubscription_MetadataEntry_DoNotUse.base,
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRoutes.base,}};
+
+static void InitDefaultsTopicRoutes() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_TopicRoutes_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::TopicRoutes();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::TopicRoutes::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_TopicRoutes =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsTopicRoutes}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRule.base,}};
+
+static void InitDefaultsTopicRule() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_TopicRule_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::TopicRule();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::TopicRule::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_TopicRule =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsTopicRule}, {}};
 
 static void InitDefaultsListInputBindingsResponse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -218,10 +260,12 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_ListTopicSubscriptionsResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_TopicSubscription_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_TopicSubscription.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_TopicRoutes.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_TopicRule.base);
   ::google::protobuf::internal::InitSCC(&scc_info_ListInputBindingsResponse.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[9];
+::google::protobuf::Metadata file_level_metadata[11];
 const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[2];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
@@ -238,6 +282,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventRequest, data_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventRequest, topic_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventRequest, pubsub_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventRequest, path_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicEventResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -294,6 +339,21 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicSubscription, pubsub_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicSubscription, topic_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicSubscription, metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicSubscription, routes_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRoutes, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRoutes, rules_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRoutes, default__),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRule, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRule, match_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::TopicRule, path_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::ListInputBindingsResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -303,14 +363,16 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::runtime::v1::TopicEventRequest)},
-  { 13, -1, sizeof(::dapr::proto::runtime::v1::TopicEventResponse)},
-  { 19, 26, sizeof(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse)},
-  { 28, -1, sizeof(::dapr::proto::runtime::v1::BindingEventRequest)},
-  { 36, -1, sizeof(::dapr::proto::runtime::v1::BindingEventResponse)},
-  { 46, -1, sizeof(::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse)},
-  { 52, 59, sizeof(::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse)},
-  { 61, -1, sizeof(::dapr::proto::runtime::v1::TopicSubscription)},
-  { 69, -1, sizeof(::dapr::proto::runtime::v1::ListInputBindingsResponse)},
+  { 14, -1, sizeof(::dapr::proto::runtime::v1::TopicEventResponse)},
+  { 20, 27, sizeof(::dapr::proto::runtime::v1::BindingEventRequest_MetadataEntry_DoNotUse)},
+  { 29, -1, sizeof(::dapr::proto::runtime::v1::BindingEventRequest)},
+  { 37, -1, sizeof(::dapr::proto::runtime::v1::BindingEventResponse)},
+  { 47, -1, sizeof(::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse)},
+  { 53, 60, sizeof(::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse)},
+  { 62, -1, sizeof(::dapr::proto::runtime::v1::TopicSubscription)},
+  { 71, -1, sizeof(::dapr::proto::runtime::v1::TopicRoutes)},
+  { 78, -1, sizeof(::dapr::proto::runtime::v1::TopicRule)},
+  { 85, -1, sizeof(::dapr::proto::runtime::v1::ListInputBindingsResponse)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -322,6 +384,8 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_ListTopicSubscriptionsResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TopicSubscription_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TopicSubscription_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TopicRoutes_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_TopicRule_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_ListInputBindingsResponse_default_instance_),
 };
 
@@ -340,7 +404,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 9);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 11);
 }
 
 void AddDescriptorsImpl() {
@@ -349,54 +413,58 @@ void AddDescriptorsImpl() {
       "\n\'dapr/proto/runtime/v1/appcallback.prot"
       "o\022\025dapr.proto.runtime.v1\032\033google/protobu"
       "f/empty.proto\032!dapr/proto/common/v1/comm"
-      "on.proto\"\240\001\n\021TopicEventRequest\022\n\n\002id\030\001 \001"
+      "on.proto\"\256\001\n\021TopicEventRequest\022\n\n\002id\030\001 \001"
       "(\t\022\016\n\006source\030\002 \001(\t\022\014\n\004type\030\003 \001(\t\022\024\n\014spec"
       "_version\030\004 \001(\t\022\031\n\021data_content_type\030\005 \001("
       "\t\022\014\n\004data\030\007 \001(\014\022\r\n\005topic\030\006 \001(\t\022\023\n\013pubsub"
-      "_name\030\010 \001(\t\"\246\001\n\022TopicEventResponse\022R\n\006st"
-      "atus\030\001 \001(\0162B.dapr.proto.runtime.v1.Topic"
-      "EventResponse.TopicEventResponseStatus\"<"
-      "\n\030TopicEventResponseStatus\022\013\n\007SUCCESS\020\000\022"
-      "\t\n\005RETRY\020\001\022\010\n\004DROP\020\002\"\256\001\n\023BindingEventReq"
-      "uest\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022J\n\010meta"
-      "data\030\003 \003(\01328.dapr.proto.runtime.v1.Bindi"
-      "ngEventRequest.MetadataEntry\032/\n\rMetadata"
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\210\002"
-      "\n\024BindingEventResponse\022\022\n\nstore_name\030\001 \001"
-      "(\t\022/\n\006states\030\002 \003(\0132\037.dapr.proto.common.v"
-      "1.StateItem\022\n\n\002to\030\003 \003(\t\022\014\n\004data\030\004 \001(\014\022X\n"
-      "\013concurrency\030\005 \001(\0162C.dapr.proto.runtime."
-      "v1.BindingEventResponse.BindingEventConc"
-      "urrency\"7\n\027BindingEventConcurrency\022\016\n\nSE"
-      "QUENTIAL\020\000\022\014\n\010PARALLEL\020\001\"a\n\036ListTopicSub"
-      "scriptionsResponse\022\?\n\rsubscriptions\030\001 \003("
-      "\0132(.dapr.proto.runtime.v1.TopicSubscript"
-      "ion\"\262\001\n\021TopicSubscription\022\023\n\013pubsub_name"
-      "\030\001 \001(\t\022\r\n\005topic\030\002 \001(\t\022H\n\010metadata\030\003 \003(\0132"
-      "6.dapr.proto.runtime.v1.TopicSubscriptio"
-      "n.MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030"
-      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"-\n\031ListInputBin"
-      "dingsResponse\022\020\n\010bindings\030\001 \003(\t2\206\004\n\013AppC"
-      "allback\022W\n\010OnInvoke\022#.dapr.proto.common."
-      "v1.InvokeRequest\032$.dapr.proto.common.v1."
-      "InvokeResponse\"\000\022i\n\026ListTopicSubscriptio"
-      "ns\022\026.google.protobuf.Empty\0325.dapr.proto."
-      "runtime.v1.ListTopicSubscriptionsRespons"
-      "e\"\000\022e\n\014OnTopicEvent\022(.dapr.proto.runtime"
-      ".v1.TopicEventRequest\032).dapr.proto.runti"
-      "me.v1.TopicEventResponse\"\000\022_\n\021ListInputB"
-      "indings\022\026.google.protobuf.Empty\0320.dapr.p"
-      "roto.runtime.v1.ListInputBindingsRespons"
-      "e\"\000\022k\n\016OnBindingEvent\022*.dapr.proto.runti"
-      "me.v1.BindingEventRequest\032+.dapr.proto.r"
-      "untime.v1.BindingEventResponse\"\000By\n\nio.d"
-      "apr.v1B\025DaprAppCallbackProtosZ1github.co"
-      "m/dapr/dapr/pkg/proto/runtime/v1;runtime"
-      "\252\002 Dapr.AppCallback.Autogen.Grpc.v1b\006pro"
-      "to3"
+      "_name\030\010 \001(\t\022\014\n\004path\030\t \001(\t\"\246\001\n\022TopicEvent"
+      "Response\022R\n\006status\030\001 \001(\0162B.dapr.proto.ru"
+      "ntime.v1.TopicEventResponse.TopicEventRe"
+      "sponseStatus\"<\n\030TopicEventResponseStatus"
+      "\022\013\n\007SUCCESS\020\000\022\t\n\005RETRY\020\001\022\010\n\004DROP\020\002\"\256\001\n\023B"
+      "indingEventRequest\022\014\n\004name\030\001 \001(\t\022\014\n\004data"
+      "\030\002 \001(\014\022J\n\010metadata\030\003 \003(\01328.dapr.proto.ru"
+      "ntime.v1.BindingEventRequest.MetadataEnt"
+      "ry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
+      "e\030\002 \001(\t:\0028\001\"\210\002\n\024BindingEventResponse\022\022\n\n"
+      "store_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037.dapr."
+      "proto.common.v1.StateItem\022\n\n\002to\030\003 \003(\t\022\014\n"
+      "\004data\030\004 \001(\014\022X\n\013concurrency\030\005 \001(\0162C.dapr."
+      "proto.runtime.v1.BindingEventResponse.Bi"
+      "ndingEventConcurrency\"7\n\027BindingEventCon"
+      "currency\022\016\n\nSEQUENTIAL\020\000\022\014\n\010PARALLEL\020\001\"a"
+      "\n\036ListTopicSubscriptionsResponse\022\?\n\rsubs"
+      "criptions\030\001 \003(\0132(.dapr.proto.runtime.v1."
+      "TopicSubscription\"\346\001\n\021TopicSubscription\022"
+      "\023\n\013pubsub_name\030\001 \001(\t\022\r\n\005topic\030\002 \001(\t\022H\n\010m"
+      "etadata\030\003 \003(\01326.dapr.proto.runtime.v1.To"
+      "picSubscription.MetadataEntry\0222\n\006routes\030"
+      "\005 \001(\0132\".dapr.proto.runtime.v1.TopicRoute"
+      "s\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+      "\030\002 \001(\t:\0028\001\"O\n\013TopicRoutes\022/\n\005rules\030\001 \003(\013"
+      "2 .dapr.proto.runtime.v1.TopicRule\022\017\n\007de"
+      "fault\030\002 \001(\t\"(\n\tTopicRule\022\r\n\005match\030\001 \001(\t\022"
+      "\014\n\004path\030\002 \001(\t\"-\n\031ListInputBindingsRespon"
+      "se\022\020\n\010bindings\030\001 \003(\t2\206\004\n\013AppCallback\022W\n\010"
+      "OnInvoke\022#.dapr.proto.common.v1.InvokeRe"
+      "quest\032$.dapr.proto.common.v1.InvokeRespo"
+      "nse\"\000\022i\n\026ListTopicSubscriptions\022\026.google"
+      ".protobuf.Empty\0325.dapr.proto.runtime.v1."
+      "ListTopicSubscriptionsResponse\"\000\022e\n\014OnTo"
+      "picEvent\022(.dapr.proto.runtime.v1.TopicEv"
+      "entRequest\032).dapr.proto.runtime.v1.Topic"
+      "EventResponse\"\000\022_\n\021ListInputBindings\022\026.g"
+      "oogle.protobuf.Empty\0320.dapr.proto.runtim"
+      "e.v1.ListInputBindingsResponse\"\000\022k\n\016OnBi"
+      "ndingEvent\022*.dapr.proto.runtime.v1.Bindi"
+      "ngEventRequest\032+.dapr.proto.runtime.v1.B"
+      "indingEventResponse\"\000By\n\nio.dapr.v1B\025Dap"
+      "rAppCallbackProtosZ1github.com/dapr/dapr"
+      "/pkg/proto/runtime/v1;runtime\252\002 Dapr.App"
+      "Callback.Autogen.Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 1883);
+      descriptor, 2072);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/appcallback.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fempty_2eproto::AddDescriptors();
@@ -476,6 +544,7 @@ const int TopicEventRequest::kDataContentTypeFieldNumber;
 const int TopicEventRequest::kDataFieldNumber;
 const int TopicEventRequest::kTopicFieldNumber;
 const int TopicEventRequest::kPubsubNameFieldNumber;
+const int TopicEventRequest::kPathFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 TopicEventRequest::TopicEventRequest()
@@ -521,6 +590,10 @@ TopicEventRequest::TopicEventRequest(const TopicEventRequest& from)
   if (from.pubsub_name().size() > 0) {
     pubsub_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.pubsub_name_);
   }
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.path().size() > 0) {
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.TopicEventRequest)
 }
 
@@ -533,6 +606,7 @@ void TopicEventRequest::SharedCtor() {
   topic_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   pubsub_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 TopicEventRequest::~TopicEventRequest() {
@@ -549,6 +623,7 @@ void TopicEventRequest::SharedDtor() {
   topic_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   pubsub_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void TopicEventRequest::SetCachedSize(int size) const {
@@ -579,6 +654,7 @@ void TopicEventRequest::Clear() {
   topic_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   pubsub_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -716,6 +792,22 @@ bool TopicEventRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // string path = 9;
+      case 9: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(74u /* 74 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_path()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->path().data(), static_cast<int>(this->path().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.TopicEventRequest.path"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -818,6 +910,16 @@ void TopicEventRequest::SerializeWithCachedSizes(
       8, this->pubsub_name(), output);
   }
 
+  // string path = 9;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicEventRequest.path");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      9, this->path(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -916,6 +1018,17 @@ void TopicEventRequest::SerializeWithCachedSizes(
         8, this->pubsub_name(), target);
   }
 
+  // string path = 9;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicEventRequest.path");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        9, this->path(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -989,6 +1102,13 @@ size_t TopicEventRequest::ByteSizeLong() const {
         this->pubsub_name());
   }
 
+  // string path = 9;
+  if (this->path().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->path());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -1048,6 +1168,10 @@ void TopicEventRequest::MergeFrom(const TopicEventRequest& from) {
 
     pubsub_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.pubsub_name_);
   }
+  if (from.path().size() > 0) {
+
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
 }
 
 void TopicEventRequest::CopyFrom(const ::google::protobuf::Message& from) {
@@ -1089,6 +1213,8 @@ void TopicEventRequest::InternalSwap(TopicEventRequest* other) {
   data_.Swap(&other->data_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   pubsub_name_.Swap(&other->pubsub_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  path_.Swap(&other->path_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
@@ -2461,11 +2587,14 @@ void TopicSubscription_MetadataEntry_DoNotUse::MergeFrom(
 // ===================================================================
 
 void TopicSubscription::InitAsDefaultInstance() {
+  ::dapr::proto::runtime::v1::_TopicSubscription_default_instance_._instance.get_mutable()->routes_ = const_cast< ::dapr::proto::runtime::v1::TopicRoutes*>(
+      ::dapr::proto::runtime::v1::TopicRoutes::internal_default_instance());
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int TopicSubscription::kPubsubNameFieldNumber;
 const int TopicSubscription::kTopicFieldNumber;
 const int TopicSubscription::kMetadataFieldNumber;
+const int TopicSubscription::kRoutesFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 TopicSubscription::TopicSubscription()
@@ -2488,12 +2617,18 @@ TopicSubscription::TopicSubscription(const TopicSubscription& from)
   if (from.topic().size() > 0) {
     topic_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.topic_);
   }
+  if (from.has_routes()) {
+    routes_ = new ::dapr::proto::runtime::v1::TopicRoutes(*from.routes_);
+  } else {
+    routes_ = NULL;
+  }
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.TopicSubscription)
 }
 
 void TopicSubscription::SharedCtor() {
   pubsub_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   topic_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  routes_ = NULL;
 }
 
 TopicSubscription::~TopicSubscription() {
@@ -2504,6 +2639,7 @@ TopicSubscription::~TopicSubscription() {
 void TopicSubscription::SharedDtor() {
   pubsub_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   topic_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete routes_;
 }
 
 void TopicSubscription::SetCachedSize(int size) const {
@@ -2529,6 +2665,10 @@ void TopicSubscription::Clear() {
   metadata_.Clear();
   pubsub_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   topic_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (GetArenaNoVirtual() == NULL && routes_ != NULL) {
+    delete routes_;
+  }
+  routes_ = NULL;
   _internal_metadata_.Clear();
 }
 
@@ -2595,6 +2735,18 @@ bool TopicSubscription::MergePartialFromCodedStream(
             parser.value().data(), static_cast<int>(parser.value().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
             "dapr.proto.runtime.v1.TopicSubscription.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+      case 5: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_routes()));
         } else {
           goto handle_unusual;
         }
@@ -2700,6 +2852,12 @@ void TopicSubscription::SerializeWithCachedSizes(
     }
   }
 
+  // .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+  if (this->has_routes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      5, this->_internal_routes(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -2793,6 +2951,13 @@ void TopicSubscription::SerializeWithCachedSizes(
     }
   }
 
+  // .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+  if (this->has_routes()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        5, this->_internal_routes(), deterministic, target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -2838,6 +3003,13 @@ size_t TopicSubscription::ByteSizeLong() const {
         this->topic());
   }
 
+  // .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+  if (this->has_routes()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *routes_);
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -2874,6 +3046,9 @@ void TopicSubscription::MergeFrom(const TopicSubscription& from) {
 
     topic_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.topic_);
   }
+  if (from.has_routes()) {
+    mutable_routes()->::dapr::proto::runtime::v1::TopicRoutes::MergeFrom(from.routes());
+  }
 }
 
 void TopicSubscription::CopyFrom(const ::google::protobuf::Message& from) {
@@ -2905,10 +3080,598 @@ void TopicSubscription::InternalSwap(TopicSubscription* other) {
     GetArenaNoVirtual());
   topic_.Swap(&other->topic_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
+  swap(routes_, other->routes_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
 ::google::protobuf::Metadata TopicSubscription::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void TopicRoutes::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int TopicRoutes::kRulesFieldNumber;
+const int TopicRoutes::kDefaultFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+TopicRoutes::TopicRoutes()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRoutes.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.TopicRoutes)
+}
+TopicRoutes::TopicRoutes(const TopicRoutes& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      rules_(from.rules_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  default__.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.default_().size() > 0) {
+    default__.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.default__);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.TopicRoutes)
+}
+
+void TopicRoutes::SharedCtor() {
+  default__.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+TopicRoutes::~TopicRoutes() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.TopicRoutes)
+  SharedDtor();
+}
+
+void TopicRoutes::SharedDtor() {
+  default__.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void TopicRoutes::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* TopicRoutes::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const TopicRoutes& TopicRoutes::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRoutes.base);
+  return *internal_default_instance();
+}
+
+
+void TopicRoutes::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.TopicRoutes)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  rules_.Clear();
+  default__.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool TopicRoutes::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.TopicRoutes)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_rules()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string default = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_default_()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->default_().data(), static_cast<int>(this->default_().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.TopicRoutes.default"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.TopicRoutes)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.TopicRoutes)
+  return false;
+#undef DO_
+}
+
+void TopicRoutes::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.TopicRoutes)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->rules_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1,
+      this->rules(static_cast<int>(i)),
+      output);
+  }
+
+  // string default = 2;
+  if (this->default_().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->default_().data(), static_cast<int>(this->default_().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRoutes.default");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->default_(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.TopicRoutes)
+}
+
+::google::protobuf::uint8* TopicRoutes::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.TopicRoutes)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->rules_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, this->rules(static_cast<int>(i)), deterministic, target);
+  }
+
+  // string default = 2;
+  if (this->default_().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->default_().data(), static_cast<int>(this->default_().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRoutes.default");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->default_(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.TopicRoutes)
+  return target;
+}
+
+size_t TopicRoutes::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.TopicRoutes)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+  {
+    unsigned int count = static_cast<unsigned int>(this->rules_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->rules(static_cast<int>(i)));
+    }
+  }
+
+  // string default = 2;
+  if (this->default_().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->default_());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TopicRoutes::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.TopicRoutes)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TopicRoutes* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const TopicRoutes>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.TopicRoutes)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.TopicRoutes)
+    MergeFrom(*source);
+  }
+}
+
+void TopicRoutes::MergeFrom(const TopicRoutes& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.TopicRoutes)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  rules_.MergeFrom(from.rules_);
+  if (from.default_().size() > 0) {
+
+    default__.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.default__);
+  }
+}
+
+void TopicRoutes::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.TopicRoutes)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TopicRoutes::CopyFrom(const TopicRoutes& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.TopicRoutes)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TopicRoutes::IsInitialized() const {
+  return true;
+}
+
+void TopicRoutes::Swap(TopicRoutes* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void TopicRoutes::InternalSwap(TopicRoutes* other) {
+  using std::swap;
+  CastToBase(&rules_)->InternalSwap(CastToBase(&other->rules_));
+  default__.Swap(&other->default__, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata TopicRoutes::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void TopicRule::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int TopicRule::kMatchFieldNumber;
+const int TopicRule::kPathFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+TopicRule::TopicRule()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRule.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.TopicRule)
+}
+TopicRule::TopicRule(const TopicRule& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  match_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.match().size() > 0) {
+    match_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.match_);
+  }
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.path().size() > 0) {
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.TopicRule)
+}
+
+void TopicRule::SharedCtor() {
+  match_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+TopicRule::~TopicRule() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.TopicRule)
+  SharedDtor();
+}
+
+void TopicRule::SharedDtor() {
+  match_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void TopicRule::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* TopicRule::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const TopicRule& TopicRule::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::scc_info_TopicRule.base);
+  return *internal_default_instance();
+}
+
+
+void TopicRule::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.TopicRule)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  match_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool TopicRule::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.TopicRule)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string match = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_match()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->match().data(), static_cast<int>(this->match().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.TopicRule.match"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string path = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_path()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->path().data(), static_cast<int>(this->path().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.TopicRule.path"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.TopicRule)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.TopicRule)
+  return false;
+#undef DO_
+}
+
+void TopicRule::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.TopicRule)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string match = 1;
+  if (this->match().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->match().data(), static_cast<int>(this->match().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRule.match");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->match(), output);
+  }
+
+  // string path = 2;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRule.path");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->path(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.TopicRule)
+}
+
+::google::protobuf::uint8* TopicRule::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.TopicRule)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string match = 1;
+  if (this->match().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->match().data(), static_cast<int>(this->match().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRule.match");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->match(), target);
+  }
+
+  // string path = 2;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.TopicRule.path");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->path(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.TopicRule)
+  return target;
+}
+
+size_t TopicRule::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.TopicRule)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string match = 1;
+  if (this->match().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->match());
+  }
+
+  // string path = 2;
+  if (this->path().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->path());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void TopicRule::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.TopicRule)
+  GOOGLE_DCHECK_NE(&from, this);
+  const TopicRule* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const TopicRule>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.TopicRule)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.TopicRule)
+    MergeFrom(*source);
+  }
+}
+
+void TopicRule::MergeFrom(const TopicRule& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.TopicRule)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.match().size() > 0) {
+
+    match_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.match_);
+  }
+  if (from.path().size() > 0) {
+
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
+}
+
+void TopicRule::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.TopicRule)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void TopicRule::CopyFrom(const TopicRule& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.TopicRule)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool TopicRule::IsInitialized() const {
+  return true;
+}
+
+void TopicRule::Swap(TopicRule* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void TopicRule::InternalSwap(TopicRule* other) {
+  using std::swap;
+  match_.Swap(&other->match_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  path_.Swap(&other->path_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata TopicRule::GetMetadata() const {
   protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -3178,6 +3941,12 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::TopicS
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::TopicSubscription* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::TopicSubscription >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::TopicSubscription >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::TopicRoutes* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::TopicRoutes >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::TopicRoutes >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::TopicRule* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::TopicRule >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::TopicRule >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::ListInputBindingsResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::ListInputBindingsResponse >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::ListInputBindingsResponse >(arena);

--- a/src/dapr/proto/runtime/v1/appcallback.pb.h
+++ b/src/dapr/proto/runtime/v1/appcallback.pb.h
@@ -44,7 +44,7 @@ namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[9];
+  static const ::google::protobuf::internal::ParseTable schema[11];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -76,6 +76,12 @@ extern TopicEventRequestDefaultTypeInternal _TopicEventRequest_default_instance_
 class TopicEventResponse;
 class TopicEventResponseDefaultTypeInternal;
 extern TopicEventResponseDefaultTypeInternal _TopicEventResponse_default_instance_;
+class TopicRoutes;
+class TopicRoutesDefaultTypeInternal;
+extern TopicRoutesDefaultTypeInternal _TopicRoutes_default_instance_;
+class TopicRule;
+class TopicRuleDefaultTypeInternal;
+extern TopicRuleDefaultTypeInternal _TopicRule_default_instance_;
 class TopicSubscription;
 class TopicSubscriptionDefaultTypeInternal;
 extern TopicSubscriptionDefaultTypeInternal _TopicSubscription_default_instance_;
@@ -95,6 +101,8 @@ template<> ::dapr::proto::runtime::v1::ListInputBindingsResponse* Arena::CreateM
 template<> ::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::ListTopicSubscriptionsResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::TopicEventRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicEventRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::TopicEventResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicEventResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::TopicRoutes* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicRoutes>(Arena*);
+template<> ::dapr::proto::runtime::v1::TopicRule* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicRule>(Arena*);
 template<> ::dapr::proto::runtime::v1::TopicSubscription* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicSubscription>(Arena*);
 template<> ::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TopicSubscription_MetadataEntry_DoNotUse>(Arena*);
 }  // namespace protobuf
@@ -348,6 +356,20 @@ class TopicEventRequest : public ::google::protobuf::Message /* @@protoc_inserti
   ::std::string* release_pubsub_name();
   void set_allocated_pubsub_name(::std::string* pubsub_name);
 
+  // string path = 9;
+  void clear_path();
+  static const int kPathFieldNumber = 9;
+  const ::std::string& path() const;
+  void set_path(const ::std::string& value);
+  #if LANG_CXX11
+  void set_path(::std::string&& value);
+  #endif
+  void set_path(const char* value);
+  void set_path(const char* value, size_t size);
+  ::std::string* mutable_path();
+  ::std::string* release_path();
+  void set_allocated_path(::std::string* path);
+
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.TopicEventRequest)
  private:
 
@@ -360,6 +382,7 @@ class TopicEventRequest : public ::google::protobuf::Message /* @@protoc_inserti
   ::google::protobuf::internal::ArenaStringPtr topic_;
   ::google::protobuf::internal::ArenaStringPtr data_;
   ::google::protobuf::internal::ArenaStringPtr pubsub_name_;
+  ::google::protobuf::internal::ArenaStringPtr path_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::TableStruct;
 };
@@ -1109,6 +1132,18 @@ class TopicSubscription : public ::google::protobuf::Message /* @@protoc_inserti
   ::std::string* release_topic();
   void set_allocated_topic(::std::string* topic);
 
+  // .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+  bool has_routes() const;
+  void clear_routes();
+  static const int kRoutesFieldNumber = 5;
+  private:
+  const ::dapr::proto::runtime::v1::TopicRoutes& _internal_routes() const;
+  public:
+  const ::dapr::proto::runtime::v1::TopicRoutes& routes() const;
+  ::dapr::proto::runtime::v1::TopicRoutes* release_routes();
+  ::dapr::proto::runtime::v1::TopicRoutes* mutable_routes();
+  void set_allocated_routes(::dapr::proto::runtime::v1::TopicRoutes* routes);
+
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.TopicSubscription)
  private:
 
@@ -1121,6 +1156,257 @@ class TopicSubscription : public ::google::protobuf::Message /* @@protoc_inserti
       0 > metadata_;
   ::google::protobuf::internal::ArenaStringPtr pubsub_name_;
   ::google::protobuf::internal::ArenaStringPtr topic_;
+  ::dapr::proto::runtime::v1::TopicRoutes* routes_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class TopicRoutes : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.TopicRoutes) */ {
+ public:
+  TopicRoutes();
+  virtual ~TopicRoutes();
+
+  TopicRoutes(const TopicRoutes& from);
+
+  inline TopicRoutes& operator=(const TopicRoutes& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  TopicRoutes(TopicRoutes&& from) noexcept
+    : TopicRoutes() {
+    *this = ::std::move(from);
+  }
+
+  inline TopicRoutes& operator=(TopicRoutes&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const TopicRoutes& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const TopicRoutes* internal_default_instance() {
+    return reinterpret_cast<const TopicRoutes*>(
+               &_TopicRoutes_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  void Swap(TopicRoutes* other);
+  friend void swap(TopicRoutes& a, TopicRoutes& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TopicRoutes* New() const final {
+    return CreateMaybeMessage<TopicRoutes>(NULL);
+  }
+
+  TopicRoutes* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<TopicRoutes>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const TopicRoutes& from);
+  void MergeFrom(const TopicRoutes& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TopicRoutes* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+  int rules_size() const;
+  void clear_rules();
+  static const int kRulesFieldNumber = 1;
+  ::dapr::proto::runtime::v1::TopicRule* mutable_rules(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::TopicRule >*
+      mutable_rules();
+  const ::dapr::proto::runtime::v1::TopicRule& rules(int index) const;
+  ::dapr::proto::runtime::v1::TopicRule* add_rules();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::TopicRule >&
+      rules() const;
+
+  // string default = 2;
+  void clear_default_();
+  static const int kDefaultFieldNumber = 2;
+  const ::std::string& default_() const;
+  void set_default_(const ::std::string& value);
+  #if LANG_CXX11
+  void set_default_(::std::string&& value);
+  #endif
+  void set_default_(const char* value);
+  void set_default_(const char* value, size_t size);
+  ::std::string* mutable_default_();
+  ::std::string* release_default_();
+  void set_allocated_default_(::std::string* default_);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.TopicRoutes)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::TopicRule > rules_;
+  ::google::protobuf::internal::ArenaStringPtr default__;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class TopicRule : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.TopicRule) */ {
+ public:
+  TopicRule();
+  virtual ~TopicRule();
+
+  TopicRule(const TopicRule& from);
+
+  inline TopicRule& operator=(const TopicRule& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  TopicRule(TopicRule&& from) noexcept
+    : TopicRule() {
+    *this = ::std::move(from);
+  }
+
+  inline TopicRule& operator=(TopicRule&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const TopicRule& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const TopicRule* internal_default_instance() {
+    return reinterpret_cast<const TopicRule*>(
+               &_TopicRule_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    9;
+
+  void Swap(TopicRule* other);
+  friend void swap(TopicRule& a, TopicRule& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline TopicRule* New() const final {
+    return CreateMaybeMessage<TopicRule>(NULL);
+  }
+
+  TopicRule* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<TopicRule>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const TopicRule& from);
+  void MergeFrom(const TopicRule& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(TopicRule* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string match = 1;
+  void clear_match();
+  static const int kMatchFieldNumber = 1;
+  const ::std::string& match() const;
+  void set_match(const ::std::string& value);
+  #if LANG_CXX11
+  void set_match(::std::string&& value);
+  #endif
+  void set_match(const char* value);
+  void set_match(const char* value, size_t size);
+  ::std::string* mutable_match();
+  ::std::string* release_match();
+  void set_allocated_match(::std::string* match);
+
+  // string path = 2;
+  void clear_path();
+  static const int kPathFieldNumber = 2;
+  const ::std::string& path() const;
+  void set_path(const ::std::string& value);
+  #if LANG_CXX11
+  void set_path(::std::string&& value);
+  #endif
+  void set_path(const char* value);
+  void set_path(const char* value, size_t size);
+  ::std::string* mutable_path();
+  ::std::string* release_path();
+  void set_allocated_path(::std::string* path);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.TopicRule)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr match_;
+  ::google::protobuf::internal::ArenaStringPtr path_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fappcallback_2eproto::TableStruct;
 };
@@ -1161,7 +1447,7 @@ class ListInputBindingsResponse : public ::google::protobuf::Message /* @@protoc
                &_ListInputBindingsResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    10;
 
   void Swap(ListInputBindingsResponse* other);
   friend void swap(ListInputBindingsResponse& a, ListInputBindingsResponse& b) {
@@ -1676,6 +1962,59 @@ inline void TopicEventRequest::set_allocated_pubsub_name(::std::string* pubsub_n
   }
   pubsub_name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), pubsub_name);
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicEventRequest.pubsub_name)
+}
+
+// string path = 9;
+inline void TopicEventRequest::clear_path() {
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& TopicEventRequest::path() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicEventRequest.path)
+  return path_.GetNoArena();
+}
+inline void TopicEventRequest::set_path(const ::std::string& value) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.TopicEventRequest.path)
+}
+#if LANG_CXX11
+inline void TopicEventRequest::set_path(::std::string&& value) {
+  
+  path_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.TopicEventRequest.path)
+}
+#endif
+inline void TopicEventRequest::set_path(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.TopicEventRequest.path)
+}
+inline void TopicEventRequest::set_path(const char* value, size_t size) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.TopicEventRequest.path)
+}
+inline ::std::string* TopicEventRequest::mutable_path() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicEventRequest.path)
+  return path_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* TopicEventRequest::release_path() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.TopicEventRequest.path)
+  
+  return path_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void TopicEventRequest::set_allocated_path(::std::string* path) {
+  if (path != NULL) {
+    
+  } else {
+    
+  }
+  path_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), path);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicEventRequest.path)
 }
 
 // -------------------------------------------------------------------
@@ -2210,6 +2549,257 @@ TopicSubscription::mutable_metadata() {
   return metadata_.MutableMap();
 }
 
+// .dapr.proto.runtime.v1.TopicRoutes routes = 5;
+inline bool TopicSubscription::has_routes() const {
+  return this != internal_default_instance() && routes_ != NULL;
+}
+inline void TopicSubscription::clear_routes() {
+  if (GetArenaNoVirtual() == NULL && routes_ != NULL) {
+    delete routes_;
+  }
+  routes_ = NULL;
+}
+inline const ::dapr::proto::runtime::v1::TopicRoutes& TopicSubscription::_internal_routes() const {
+  return *routes_;
+}
+inline const ::dapr::proto::runtime::v1::TopicRoutes& TopicSubscription::routes() const {
+  const ::dapr::proto::runtime::v1::TopicRoutes* p = routes_;
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicSubscription.routes)
+  return p != NULL ? *p : *reinterpret_cast<const ::dapr::proto::runtime::v1::TopicRoutes*>(
+      &::dapr::proto::runtime::v1::_TopicRoutes_default_instance_);
+}
+inline ::dapr::proto::runtime::v1::TopicRoutes* TopicSubscription::release_routes() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.TopicSubscription.routes)
+  
+  ::dapr::proto::runtime::v1::TopicRoutes* temp = routes_;
+  routes_ = NULL;
+  return temp;
+}
+inline ::dapr::proto::runtime::v1::TopicRoutes* TopicSubscription::mutable_routes() {
+  
+  if (routes_ == NULL) {
+    auto* p = CreateMaybeMessage<::dapr::proto::runtime::v1::TopicRoutes>(GetArenaNoVirtual());
+    routes_ = p;
+  }
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicSubscription.routes)
+  return routes_;
+}
+inline void TopicSubscription::set_allocated_routes(::dapr::proto::runtime::v1::TopicRoutes* routes) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete routes_;
+  }
+  if (routes) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      routes = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, routes, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  routes_ = routes;
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicSubscription.routes)
+}
+
+// -------------------------------------------------------------------
+
+// TopicRoutes
+
+// repeated .dapr.proto.runtime.v1.TopicRule rules = 1;
+inline int TopicRoutes::rules_size() const {
+  return rules_.size();
+}
+inline void TopicRoutes::clear_rules() {
+  rules_.Clear();
+}
+inline ::dapr::proto::runtime::v1::TopicRule* TopicRoutes::mutable_rules(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicRoutes.rules)
+  return rules_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::TopicRule >*
+TopicRoutes::mutable_rules() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.TopicRoutes.rules)
+  return &rules_;
+}
+inline const ::dapr::proto::runtime::v1::TopicRule& TopicRoutes::rules(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicRoutes.rules)
+  return rules_.Get(index);
+}
+inline ::dapr::proto::runtime::v1::TopicRule* TopicRoutes::add_rules() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.TopicRoutes.rules)
+  return rules_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::TopicRule >&
+TopicRoutes::rules() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.TopicRoutes.rules)
+  return rules_;
+}
+
+// string default = 2;
+inline void TopicRoutes::clear_default_() {
+  default__.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& TopicRoutes::default_() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicRoutes.default)
+  return default__.GetNoArena();
+}
+inline void TopicRoutes::set_default_(const ::std::string& value) {
+  
+  default__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.TopicRoutes.default)
+}
+#if LANG_CXX11
+inline void TopicRoutes::set_default_(::std::string&& value) {
+  
+  default__.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.TopicRoutes.default)
+}
+#endif
+inline void TopicRoutes::set_default_(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  default__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.TopicRoutes.default)
+}
+inline void TopicRoutes::set_default_(const char* value, size_t size) {
+  
+  default__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.TopicRoutes.default)
+}
+inline ::std::string* TopicRoutes::mutable_default_() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicRoutes.default)
+  return default__.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* TopicRoutes::release_default_() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.TopicRoutes.default)
+  
+  return default__.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void TopicRoutes::set_allocated_default_(::std::string* default_) {
+  if (default_ != NULL) {
+    
+  } else {
+    
+  }
+  default__.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), default_);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicRoutes.default)
+}
+
+// -------------------------------------------------------------------
+
+// TopicRule
+
+// string match = 1;
+inline void TopicRule::clear_match() {
+  match_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& TopicRule::match() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicRule.match)
+  return match_.GetNoArena();
+}
+inline void TopicRule::set_match(const ::std::string& value) {
+  
+  match_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.TopicRule.match)
+}
+#if LANG_CXX11
+inline void TopicRule::set_match(::std::string&& value) {
+  
+  match_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.TopicRule.match)
+}
+#endif
+inline void TopicRule::set_match(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  match_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.TopicRule.match)
+}
+inline void TopicRule::set_match(const char* value, size_t size) {
+  
+  match_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.TopicRule.match)
+}
+inline ::std::string* TopicRule::mutable_match() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicRule.match)
+  return match_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* TopicRule::release_match() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.TopicRule.match)
+  
+  return match_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void TopicRule::set_allocated_match(::std::string* match) {
+  if (match != NULL) {
+    
+  } else {
+    
+  }
+  match_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), match);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicRule.match)
+}
+
+// string path = 2;
+inline void TopicRule::clear_path() {
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& TopicRule::path() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.TopicRule.path)
+  return path_.GetNoArena();
+}
+inline void TopicRule::set_path(const ::std::string& value) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.TopicRule.path)
+}
+#if LANG_CXX11
+inline void TopicRule::set_path(::std::string&& value) {
+  
+  path_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.TopicRule.path)
+}
+#endif
+inline void TopicRule::set_path(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.TopicRule.path)
+}
+inline void TopicRule::set_path(const char* value, size_t size) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.TopicRule.path)
+}
+inline ::std::string* TopicRule::mutable_path() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.TopicRule.path)
+  return path_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* TopicRule::release_path() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.TopicRule.path)
+  
+  return path_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void TopicRule::set_allocated_path(::std::string* path) {
+  if (path != NULL) {
+    
+  } else {
+    
+  }
+  path_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), path);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.TopicRule.path)
+}
+
 // -------------------------------------------------------------------
 
 // ListInputBindingsResponse
@@ -2286,6 +2876,10 @@ ListInputBindingsResponse::mutable_bindings() {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.cc
@@ -25,6 +25,7 @@ static const char* Dapr_method_names[] = {
   "/dapr.proto.runtime.v1.Dapr/GetState",
   "/dapr.proto.runtime.v1.Dapr/GetBulkState",
   "/dapr.proto.runtime.v1.Dapr/SaveState",
+  "/dapr.proto.runtime.v1.Dapr/QueryStateAlpha1",
   "/dapr.proto.runtime.v1.Dapr/DeleteState",
   "/dapr.proto.runtime.v1.Dapr/DeleteBulkState",
   "/dapr.proto.runtime.v1.Dapr/ExecuteStateTransaction",
@@ -39,6 +40,8 @@ static const char* Dapr_method_names[] = {
   "/dapr.proto.runtime.v1.Dapr/GetActorState",
   "/dapr.proto.runtime.v1.Dapr/ExecuteActorStateTransaction",
   "/dapr.proto.runtime.v1.Dapr/InvokeActor",
+  "/dapr.proto.runtime.v1.Dapr/GetConfigurationAlpha1",
+  "/dapr.proto.runtime.v1.Dapr/SubscribeConfigurationAlpha1",
   "/dapr.proto.runtime.v1.Dapr/GetMetadata",
   "/dapr.proto.runtime.v1.Dapr/SetMetadata",
   "/dapr.proto.runtime.v1.Dapr/Shutdown",
@@ -55,23 +58,26 @@ Dapr::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   , rpcmethod_GetState_(Dapr_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_GetBulkState_(Dapr_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SaveState_(Dapr_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DeleteState_(Dapr_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DeleteBulkState_(Dapr_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ExecuteStateTransaction_(Dapr_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_PublishEvent_(Dapr_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_InvokeBinding_(Dapr_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetSecret_(Dapr_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetBulkSecret_(Dapr_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RegisterActorTimer_(Dapr_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UnregisterActorTimer_(Dapr_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RegisterActorReminder_(Dapr_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UnregisterActorReminder_(Dapr_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetActorState_(Dapr_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ExecuteActorStateTransaction_(Dapr_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_InvokeActor_(Dapr_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetMetadata_(Dapr_method_names[18], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetMetadata_(Dapr_method_names[19], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Shutdown_(Dapr_method_names[20], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_QueryStateAlpha1_(Dapr_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DeleteState_(Dapr_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DeleteBulkState_(Dapr_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ExecuteStateTransaction_(Dapr_method_names[7], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_PublishEvent_(Dapr_method_names[8], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_InvokeBinding_(Dapr_method_names[9], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetSecret_(Dapr_method_names[10], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetBulkSecret_(Dapr_method_names[11], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RegisterActorTimer_(Dapr_method_names[12], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UnregisterActorTimer_(Dapr_method_names[13], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RegisterActorReminder_(Dapr_method_names[14], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UnregisterActorReminder_(Dapr_method_names[15], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetActorState_(Dapr_method_names[16], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ExecuteActorStateTransaction_(Dapr_method_names[17], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_InvokeActor_(Dapr_method_names[18], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetConfigurationAlpha1_(Dapr_method_names[19], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeConfigurationAlpha1_(Dapr_method_names[20], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_GetMetadata_(Dapr_method_names[21], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetMetadata_(Dapr_method_names[22], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Shutdown_(Dapr_method_names[23], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status Dapr::Stub::InvokeService(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeServiceRequest& request, ::dapr::proto::common::v1::InvokeResponse* response) {
@@ -136,6 +142,22 @@ void Dapr::Stub::experimental_async::SaveState(::grpc::ClientContext* context, c
 
 ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* Dapr::Stub::PrepareAsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_SaveState_, context, request, false);
+}
+
+::grpc::Status Dapr::Stub::QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::dapr::proto::runtime::v1::QueryStateResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_QueryStateAlpha1_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_QueryStateAlpha1_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>* Dapr::Stub::AsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::QueryStateResponse>::Create(channel_.get(), cq, rpcmethod_QueryStateAlpha1_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>* Dapr::Stub::PrepareAsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::QueryStateResponse>::Create(channel_.get(), cq, rpcmethod_QueryStateAlpha1_, context, request, false);
 }
 
 ::grpc::Status Dapr::Stub::DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::google::protobuf::Empty* response) {
@@ -362,6 +384,34 @@ void Dapr::Stub::experimental_async::InvokeActor(::grpc::ClientContext* context,
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::InvokeActorResponse>::Create(channel_.get(), cq, rpcmethod_InvokeActor_, context, request, false);
 }
 
+::grpc::Status Dapr::Stub::GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetConfigurationAlpha1_, context, request, response);
+}
+
+void Dapr::Stub::experimental_async::GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetConfigurationAlpha1_, context, request, response, std::move(f));
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>* Dapr::Stub::AsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::GetConfigurationResponse>::Create(channel_.get(), cq, rpcmethod_GetConfigurationAlpha1_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>* Dapr::Stub::PrepareAsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::dapr::proto::runtime::v1::GetConfigurationResponse>::Create(channel_.get(), cq, rpcmethod_GetConfigurationAlpha1_, context, request, false);
+}
+
+::grpc::ClientReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* Dapr::Stub::SubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>::Create(channel_.get(), rpcmethod_SubscribeConfigurationAlpha1_, context, request);
+}
+
+::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* Dapr::Stub::AsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeConfigurationAlpha1_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* Dapr::Stub::PrepareAsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeConfigurationAlpha1_, context, request, false, nullptr);
+}
+
 ::grpc::Status Dapr::Stub::GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetMetadata_, context, request, response);
 }
@@ -434,85 +484,100 @@ Dapr::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Dapr_method_names[4],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::QueryStateRequest, ::dapr::proto::runtime::v1::QueryStateResponse>(
+          std::mem_fn(&Dapr::Service::QueryStateAlpha1), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[5],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::DeleteStateRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::DeleteState), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[5],
+      Dapr_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::DeleteBulkStateRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::DeleteBulkState), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[6],
+      Dapr_method_names[7],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::ExecuteStateTransaction), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[7],
+      Dapr_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::PublishEventRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::PublishEvent), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[8],
+      Dapr_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::InvokeBindingRequest, ::dapr::proto::runtime::v1::InvokeBindingResponse>(
           std::mem_fn(&Dapr::Service::InvokeBinding), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[9],
+      Dapr_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetSecretRequest, ::dapr::proto::runtime::v1::GetSecretResponse>(
           std::mem_fn(&Dapr::Service::GetSecret), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[10],
+      Dapr_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetBulkSecretRequest, ::dapr::proto::runtime::v1::GetBulkSecretResponse>(
           std::mem_fn(&Dapr::Service::GetBulkSecret), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[11],
+      Dapr_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::RegisterActorTimerRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::RegisterActorTimer), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[12],
+      Dapr_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::UnregisterActorTimerRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::UnregisterActorTimer), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[13],
+      Dapr_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::RegisterActorReminderRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::RegisterActorReminder), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[14],
+      Dapr_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::UnregisterActorReminderRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::UnregisterActorReminder), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[15],
+      Dapr_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetActorStateRequest, ::dapr::proto::runtime::v1::GetActorStateResponse>(
           std::mem_fn(&Dapr::Service::GetActorState), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[16],
+      Dapr_method_names[17],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::ExecuteActorStateTransaction), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[17],
+      Dapr_method_names[18],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::InvokeActorRequest, ::dapr::proto::runtime::v1::InvokeActorResponse>(
           std::mem_fn(&Dapr::Service::InvokeActor), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[18],
+      Dapr_method_names[19],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::GetConfigurationRequest, ::dapr::proto::runtime::v1::GetConfigurationResponse>(
+          std::mem_fn(&Dapr::Service::GetConfigurationAlpha1), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[20],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< Dapr::Service, ::dapr::proto::runtime::v1::SubscribeConfigurationRequest, ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>(
+          std::mem_fn(&Dapr::Service::SubscribeConfigurationAlpha1), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Dapr_method_names[21],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::google::protobuf::Empty, ::dapr::proto::runtime::v1::GetMetadataResponse>(
           std::mem_fn(&Dapr::Service::GetMetadata), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[19],
+      Dapr_method_names[22],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::dapr::proto::runtime::v1::SetMetadataRequest, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::SetMetadata), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      Dapr_method_names[20],
+      Dapr_method_names[23],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< Dapr::Service, ::google::protobuf::Empty, ::google::protobuf::Empty>(
           std::mem_fn(&Dapr::Service::Shutdown), this)));
@@ -543,6 +608,13 @@ Dapr::Service::~Service() {
 }
 
 ::grpc::Status Dapr::Service::SaveState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response) {
   (void) context;
   (void) request;
   (void) response;
@@ -644,6 +716,20 @@ Dapr::Service::~Service() {
   (void) context;
   (void) request;
   (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Dapr::Service::SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 

--- a/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.grpc.pb.h
@@ -77,6 +77,14 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncSaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncSaveStateRaw(context, request, cq));
     }
+    // Queries the state.
+    virtual ::grpc::Status QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::dapr::proto::runtime::v1::QueryStateResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>> AsyncQueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>>(AsyncQueryStateAlpha1Raw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>> PrepareAsyncQueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>>(PrepareAsyncQueryStateAlpha1Raw(context, request, cq));
+    }
     // Deletes the state for a specific key.
     virtual ::grpc::Status DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::google::protobuf::Empty* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncDeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) {
@@ -189,6 +197,24 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>> PrepareAsyncInvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>>(PrepareAsyncInvokeActorRaw(context, request, cq));
     }
+    // GetConfiguration gets configuration from configuration store.
+    virtual ::grpc::Status GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>> AsyncGetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>>(AsyncGetConfigurationAlpha1Raw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>> PrepareAsyncGetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>>(PrepareAsyncGetConfigurationAlpha1Raw(context, request, cq));
+    }
+    // SubscribeConfiguration gets configuration from configuration store and subscribe the updates event by grpc stream
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> SubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(SubscribeConfigurationAlpha1Raw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> AsyncSubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(AsyncSubscribeConfigurationAlpha1Raw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> PrepareAsyncSubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(PrepareAsyncSubscribeConfigurationAlpha1Raw(context, request, cq));
+    }
     // Gets metadata of the sidecar
     virtual ::grpc::Status GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>> AsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
@@ -224,6 +250,8 @@ class Dapr final {
       virtual void GetBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest* request, ::dapr::proto::runtime::v1::GetBulkStateResponse* response, std::function<void(::grpc::Status)>) = 0;
       // Saves the state for a specific key.
       virtual void SaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      // Queries the state.
+      virtual void QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response, std::function<void(::grpc::Status)>) = 0;
       // Deletes the state for a specific key.
       virtual void DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // Deletes a bulk of state items for a list of keys
@@ -252,6 +280,9 @@ class Dapr final {
       virtual void ExecuteActorStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       // InvokeActor calls a method on an actor.
       virtual void InvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response, std::function<void(::grpc::Status)>) = 0;
+      // GetConfiguration gets configuration from configuration store.
+      virtual void GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response, std::function<void(::grpc::Status)>) = 0;
+      // SubscribeConfiguration gets configuration from configuration store and subscribe the updates event by grpc stream
       // Gets metadata of the sidecar
       virtual void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) = 0;
       // Sets value in extended metadata of the sidecar
@@ -269,6 +300,8 @@ class Dapr final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetBulkStateResponse>* PrepareAsyncGetBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>* AsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::QueryStateResponse>* PrepareAsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -297,6 +330,11 @@ class Dapr final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncExecuteActorStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>* AsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::InvokeActorResponse>* PrepareAsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>* AsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetConfigurationResponse>* PrepareAsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* SubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* AsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* PrepareAsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>* AsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -334,6 +372,13 @@ class Dapr final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncSaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncSaveStateRaw(context, request, cq));
+    }
+    ::grpc::Status QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::dapr::proto::runtime::v1::QueryStateResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>> AsyncQueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>>(AsyncQueryStateAlpha1Raw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>> PrepareAsyncQueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>>(PrepareAsyncQueryStateAlpha1Raw(context, request, cq));
     }
     ::grpc::Status DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::google::protobuf::Empty* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncDeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) {
@@ -433,6 +478,22 @@ class Dapr final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>> PrepareAsyncInvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>>(PrepareAsyncInvokeActorRaw(context, request, cq));
     }
+    ::grpc::Status GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>> AsyncGetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>>(AsyncGetConfigurationAlpha1Raw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>> PrepareAsyncGetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>>(PrepareAsyncGetConfigurationAlpha1Raw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> SubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(SubscribeConfigurationAlpha1Raw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> AsyncSubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(AsyncSubscribeConfigurationAlpha1Raw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>> PrepareAsyncSubscribeConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>>(PrepareAsyncSubscribeConfigurationAlpha1Raw(context, request, cq));
+    }
     ::grpc::Status GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::dapr::proto::runtime::v1::GetMetadataResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>> AsyncGetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>>(AsyncGetMetadataRaw(context, request, cq));
@@ -461,6 +522,7 @@ class Dapr final {
       void GetState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetStateRequest* request, ::dapr::proto::runtime::v1::GetStateResponse* response, std::function<void(::grpc::Status)>) override;
       void GetBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest* request, ::dapr::proto::runtime::v1::GetBulkStateResponse* response, std::function<void(::grpc::Status)>) override;
       void SaveState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void QueryStateAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response, std::function<void(::grpc::Status)>) override;
       void DeleteState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void DeleteBulkState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void ExecuteStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
@@ -475,6 +537,7 @@ class Dapr final {
       void GetActorState(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetActorStateRequest* request, ::dapr::proto::runtime::v1::GetActorStateResponse* response, std::function<void(::grpc::Status)>) override;
       void ExecuteActorStateTransaction(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void InvokeActor(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response, std::function<void(::grpc::Status)>) override;
+      void GetConfigurationAlpha1(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response, std::function<void(::grpc::Status)>) override;
       void GetMetadata(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response, std::function<void(::grpc::Status)>) override;
       void SetMetadata(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void Shutdown(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
@@ -497,6 +560,8 @@ class Dapr final {
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetBulkStateResponse>* PrepareAsyncGetBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncSaveStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>* AsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::QueryStateResponse>* PrepareAsyncQueryStateAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncDeleteStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncDeleteBulkStateRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::DeleteBulkStateRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -525,6 +590,11 @@ class Dapr final {
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncExecuteActorStateTransactionRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>* AsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::InvokeActorResponse>* PrepareAsyncInvokeActorRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>* AsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetConfigurationResponse>* PrepareAsyncGetConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* SubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request) override;
+    ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* AsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* PrepareAsyncSubscribeConfigurationAlpha1Raw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* AsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::dapr::proto::runtime::v1::GetMetadataResponse>* PrepareAsyncGetMetadataRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncSetMetadataRaw(::grpc::ClientContext* context, const ::dapr::proto::runtime::v1::SetMetadataRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -535,6 +605,7 @@ class Dapr final {
     const ::grpc::internal::RpcMethod rpcmethod_GetState_;
     const ::grpc::internal::RpcMethod rpcmethod_GetBulkState_;
     const ::grpc::internal::RpcMethod rpcmethod_SaveState_;
+    const ::grpc::internal::RpcMethod rpcmethod_QueryStateAlpha1_;
     const ::grpc::internal::RpcMethod rpcmethod_DeleteState_;
     const ::grpc::internal::RpcMethod rpcmethod_DeleteBulkState_;
     const ::grpc::internal::RpcMethod rpcmethod_ExecuteStateTransaction_;
@@ -549,6 +620,8 @@ class Dapr final {
     const ::grpc::internal::RpcMethod rpcmethod_GetActorState_;
     const ::grpc::internal::RpcMethod rpcmethod_ExecuteActorStateTransaction_;
     const ::grpc::internal::RpcMethod rpcmethod_InvokeActor_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetConfigurationAlpha1_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeConfigurationAlpha1_;
     const ::grpc::internal::RpcMethod rpcmethod_GetMetadata_;
     const ::grpc::internal::RpcMethod rpcmethod_SetMetadata_;
     const ::grpc::internal::RpcMethod rpcmethod_Shutdown_;
@@ -567,6 +640,8 @@ class Dapr final {
     virtual ::grpc::Status GetBulkState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetBulkStateRequest* request, ::dapr::proto::runtime::v1::GetBulkStateResponse* response);
     // Saves the state for a specific key.
     virtual ::grpc::Status SaveState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SaveStateRequest* request, ::google::protobuf::Empty* response);
+    // Queries the state.
+    virtual ::grpc::Status QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response);
     // Deletes the state for a specific key.
     virtual ::grpc::Status DeleteState(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::google::protobuf::Empty* response);
     // Deletes a bulk of state items for a list of keys
@@ -595,6 +670,10 @@ class Dapr final {
     virtual ::grpc::Status ExecuteActorStateTransaction(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::google::protobuf::Empty* response);
     // InvokeActor calls a method on an actor.
     virtual ::grpc::Status InvokeActor(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::dapr::proto::runtime::v1::InvokeActorResponse* response);
+    // GetConfiguration gets configuration from configuration store.
+    virtual ::grpc::Status GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response);
+    // SubscribeConfiguration gets configuration from configuration store and subscribe the updates event by grpc stream
+    virtual ::grpc::Status SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer);
     // Gets metadata of the sidecar
     virtual ::grpc::Status GetMetadata(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::dapr::proto::runtime::v1::GetMetadataResponse* response);
     // Sets value in extended metadata of the sidecar
@@ -683,12 +762,32 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_QueryStateAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_QueryStateAlpha1() {
+      ::grpc::Service::MarkMethodAsync(4);
+    }
+    ~WithAsyncMethod_QueryStateAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestQueryStateAlpha1(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::QueryStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::QueryStateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_DeleteState : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_DeleteState() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(5);
     }
     ~WithAsyncMethod_DeleteState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -699,7 +798,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteState(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::DeleteStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -708,7 +807,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_DeleteBulkState() {
-      ::grpc::Service::MarkMethodAsync(5);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_DeleteBulkState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -719,7 +818,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteBulkState(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::DeleteBulkStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -728,7 +827,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -739,7 +838,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteStateTransaction(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -748,7 +847,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -759,7 +858,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPublishEvent(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::PublishEventRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -768,7 +867,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -779,7 +878,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeBinding(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::InvokeBindingRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::InvokeBindingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -788,7 +887,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetSecret() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -799,7 +898,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSecret(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetSecretRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetSecretResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -808,7 +907,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -819,7 +918,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetBulkSecret(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetBulkSecretRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetBulkSecretResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -828,7 +927,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -839,7 +938,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorTimer(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::RegisterActorTimerRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -848,7 +947,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -859,7 +958,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorTimer(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::UnregisterActorTimerRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -868,7 +967,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -879,7 +978,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorReminder(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::RegisterActorReminderRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -888,7 +987,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -899,7 +998,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorReminder(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::UnregisterActorReminderRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -908,7 +1007,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetActorState() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -919,7 +1018,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetActorState(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetActorStateRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetActorStateResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -928,7 +1027,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodAsync(16);
+      ::grpc::Service::MarkMethodAsync(17);
     }
     ~WithAsyncMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -939,7 +1038,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteActorStateTransaction(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -948,7 +1047,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodAsync(17);
+      ::grpc::Service::MarkMethodAsync(18);
     }
     ~WithAsyncMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -959,7 +1058,47 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeActor(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::InvokeActorRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::InvokeActorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_GetConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_GetConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodAsync(19);
+    }
+    ~WithAsyncMethod_GetConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetConfigurationAlpha1(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetConfigurationResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_SubscribeConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodAsync(20);
+    }
+    ~WithAsyncMethod_SubscribeConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeConfigurationAlpha1(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerAsyncWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(20, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -968,7 +1107,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_GetMetadata() {
-      ::grpc::Service::MarkMethodAsync(18);
+      ::grpc::Service::MarkMethodAsync(21);
     }
     ~WithAsyncMethod_GetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -979,7 +1118,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetMetadata(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::dapr::proto::runtime::v1::GetMetadataResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -988,7 +1127,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_SetMetadata() {
-      ::grpc::Service::MarkMethodAsync(19);
+      ::grpc::Service::MarkMethodAsync(22);
     }
     ~WithAsyncMethod_SetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -999,7 +1138,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMetadata(::grpc::ServerContext* context, ::dapr::proto::runtime::v1::SetMetadataRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1008,7 +1147,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_Shutdown() {
-      ::grpc::Service::MarkMethodAsync(20);
+      ::grpc::Service::MarkMethodAsync(23);
     }
     ~WithAsyncMethod_Shutdown() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1019,10 +1158,10 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestShutdown(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_DeleteState<WithAsyncMethod_DeleteBulkState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<WithAsyncMethod_GetMetadata<WithAsyncMethod_SetMetadata<WithAsyncMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_InvokeService<WithAsyncMethod_GetState<WithAsyncMethod_GetBulkState<WithAsyncMethod_SaveState<WithAsyncMethod_QueryStateAlpha1<WithAsyncMethod_DeleteState<WithAsyncMethod_DeleteBulkState<WithAsyncMethod_ExecuteStateTransaction<WithAsyncMethod_PublishEvent<WithAsyncMethod_InvokeBinding<WithAsyncMethod_GetSecret<WithAsyncMethod_GetBulkSecret<WithAsyncMethod_RegisterActorTimer<WithAsyncMethod_UnregisterActorTimer<WithAsyncMethod_RegisterActorReminder<WithAsyncMethod_UnregisterActorReminder<WithAsyncMethod_GetActorState<WithAsyncMethod_ExecuteActorStateTransaction<WithAsyncMethod_InvokeActor<WithAsyncMethod_GetConfigurationAlpha1<WithAsyncMethod_SubscribeConfigurationAlpha1<WithAsyncMethod_GetMetadata<WithAsyncMethod_SetMetadata<WithAsyncMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithGenericMethod_InvokeService : public BaseClass {
    private:
@@ -1092,12 +1231,29 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_QueryStateAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_QueryStateAlpha1() {
+      ::grpc::Service::MarkMethodGeneric(4);
+    }
+    ~WithGenericMethod_QueryStateAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_DeleteState : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_DeleteState() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(5);
     }
     ~WithGenericMethod_DeleteState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1114,7 +1270,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_DeleteBulkState() {
-      ::grpc::Service::MarkMethodGeneric(5);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_DeleteBulkState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1131,7 +1287,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1148,7 +1304,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1165,7 +1321,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1182,7 +1338,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetSecret() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1199,7 +1355,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1216,7 +1372,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1233,7 +1389,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1250,7 +1406,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1267,7 +1423,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1284,7 +1440,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetActorState() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1301,7 +1457,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodGeneric(16);
+      ::grpc::Service::MarkMethodGeneric(17);
     }
     ~WithGenericMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1318,7 +1474,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodGeneric(17);
+      ::grpc::Service::MarkMethodGeneric(18);
     }
     ~WithGenericMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1330,12 +1486,46 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_GetConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_GetConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodGeneric(19);
+    }
+    ~WithGenericMethod_GetConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_SubscribeConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodGeneric(20);
+    }
+    ~WithGenericMethod_SubscribeConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_GetMetadata : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_GetMetadata() {
-      ::grpc::Service::MarkMethodGeneric(18);
+      ::grpc::Service::MarkMethodGeneric(21);
     }
     ~WithGenericMethod_GetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1352,7 +1542,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_SetMetadata() {
-      ::grpc::Service::MarkMethodGeneric(19);
+      ::grpc::Service::MarkMethodGeneric(22);
     }
     ~WithGenericMethod_SetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1369,7 +1559,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_Shutdown() {
-      ::grpc::Service::MarkMethodGeneric(20);
+      ::grpc::Service::MarkMethodGeneric(23);
     }
     ~WithGenericMethod_Shutdown() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1461,12 +1651,32 @@ class Dapr final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_QueryStateAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_QueryStateAlpha1() {
+      ::grpc::Service::MarkMethodRaw(4);
+    }
+    ~WithRawMethod_QueryStateAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestQueryStateAlpha1(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_DeleteState : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_DeleteState() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(5);
     }
     ~WithRawMethod_DeleteState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1477,7 +1687,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1486,7 +1696,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_DeleteBulkState() {
-      ::grpc::Service::MarkMethodRaw(5);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_DeleteBulkState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1497,7 +1707,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteBulkState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1506,7 +1716,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_ExecuteStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1517,7 +1727,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteStateTransaction(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1526,7 +1736,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_PublishEvent() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1537,7 +1747,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestPublishEvent(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1546,7 +1756,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_InvokeBinding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1557,7 +1767,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeBinding(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1566,7 +1776,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetSecret() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_GetSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1577,7 +1787,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSecret(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1586,7 +1796,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_GetBulkSecret() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1597,7 +1807,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetBulkSecret(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1606,7 +1816,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_RegisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1617,7 +1827,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorTimer(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1626,7 +1836,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_UnregisterActorTimer() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1637,7 +1847,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorTimer(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1646,7 +1856,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_RegisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1657,7 +1867,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRegisterActorReminder(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1666,7 +1876,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_UnregisterActorReminder() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1677,7 +1887,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnregisterActorReminder(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1686,7 +1896,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetActorState() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_GetActorState() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1697,7 +1907,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetActorState(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1706,7 +1916,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodRaw(16);
+      ::grpc::Service::MarkMethodRaw(17);
     }
     ~WithRawMethod_ExecuteActorStateTransaction() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1717,7 +1927,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestExecuteActorStateTransaction(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1726,7 +1936,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodRaw(17);
+      ::grpc::Service::MarkMethodRaw(18);
     }
     ~WithRawMethod_InvokeActor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1737,7 +1947,47 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInvokeActor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_GetConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_GetConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodRaw(19);
+    }
+    ~WithRawMethod_GetConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetConfigurationAlpha1(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_SubscribeConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodRaw(20);
+    }
+    ~WithRawMethod_SubscribeConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeConfigurationAlpha1(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(20, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1746,7 +1996,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_GetMetadata() {
-      ::grpc::Service::MarkMethodRaw(18);
+      ::grpc::Service::MarkMethodRaw(21);
     }
     ~WithRawMethod_GetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1757,7 +2007,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetMetadata(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1766,7 +2016,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_SetMetadata() {
-      ::grpc::Service::MarkMethodRaw(19);
+      ::grpc::Service::MarkMethodRaw(22);
     }
     ~WithRawMethod_SetMetadata() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1777,7 +2027,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetMetadata(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1786,7 +2036,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_Shutdown() {
-      ::grpc::Service::MarkMethodRaw(20);
+      ::grpc::Service::MarkMethodRaw(23);
     }
     ~WithRawMethod_Shutdown() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1797,7 +2047,7 @@ class Dapr final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestShutdown(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1881,12 +2131,32 @@ class Dapr final {
     virtual ::grpc::Status StreamedSaveState(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::SaveStateRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_QueryStateAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_QueryStateAlpha1() {
+      ::grpc::Service::MarkMethodStreamed(4,
+        new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::QueryStateRequest, ::dapr::proto::runtime::v1::QueryStateResponse>(std::bind(&WithStreamedUnaryMethod_QueryStateAlpha1<BaseClass>::StreamedQueryStateAlpha1, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_QueryStateAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status QueryStateAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::QueryStateRequest* request, ::dapr::proto::runtime::v1::QueryStateResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedQueryStateAlpha1(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::QueryStateRequest,::dapr::proto::runtime::v1::QueryStateResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_DeleteState : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_DeleteState() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(5,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::DeleteStateRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_DeleteState<BaseClass>::StreamedDeleteState, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_DeleteState() override {
@@ -1906,7 +2176,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_DeleteBulkState() {
-      ::grpc::Service::MarkMethodStreamed(5,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::DeleteBulkStateRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_DeleteBulkState<BaseClass>::StreamedDeleteBulkState, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_DeleteBulkState() override {
@@ -1926,7 +2196,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_ExecuteStateTransaction() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::ExecuteStateTransactionRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_ExecuteStateTransaction<BaseClass>::StreamedExecuteStateTransaction, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_ExecuteStateTransaction() override {
@@ -1946,7 +2216,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_PublishEvent() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::PublishEventRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_PublishEvent<BaseClass>::StreamedPublishEvent, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_PublishEvent() override {
@@ -1966,7 +2236,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_InvokeBinding() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::InvokeBindingRequest, ::dapr::proto::runtime::v1::InvokeBindingResponse>(std::bind(&WithStreamedUnaryMethod_InvokeBinding<BaseClass>::StreamedInvokeBinding, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_InvokeBinding() override {
@@ -1986,7 +2256,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetSecret() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetSecretRequest, ::dapr::proto::runtime::v1::GetSecretResponse>(std::bind(&WithStreamedUnaryMethod_GetSecret<BaseClass>::StreamedGetSecret, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetSecret() override {
@@ -2006,7 +2276,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetBulkSecret() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetBulkSecretRequest, ::dapr::proto::runtime::v1::GetBulkSecretResponse>(std::bind(&WithStreamedUnaryMethod_GetBulkSecret<BaseClass>::StreamedGetBulkSecret, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetBulkSecret() override {
@@ -2026,7 +2296,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_RegisterActorTimer() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::RegisterActorTimerRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_RegisterActorTimer<BaseClass>::StreamedRegisterActorTimer, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_RegisterActorTimer() override {
@@ -2046,7 +2316,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_UnregisterActorTimer() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::UnregisterActorTimerRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_UnregisterActorTimer<BaseClass>::StreamedUnregisterActorTimer, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_UnregisterActorTimer() override {
@@ -2066,7 +2336,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_RegisterActorReminder() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::RegisterActorReminderRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_RegisterActorReminder<BaseClass>::StreamedRegisterActorReminder, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_RegisterActorReminder() override {
@@ -2086,7 +2356,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_UnregisterActorReminder() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::UnregisterActorReminderRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_UnregisterActorReminder<BaseClass>::StreamedUnregisterActorReminder, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_UnregisterActorReminder() override {
@@ -2106,7 +2376,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetActorState() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetActorStateRequest, ::dapr::proto::runtime::v1::GetActorStateResponse>(std::bind(&WithStreamedUnaryMethod_GetActorState<BaseClass>::StreamedGetActorState, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetActorState() override {
@@ -2126,7 +2396,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_ExecuteActorStateTransaction() {
-      ::grpc::Service::MarkMethodStreamed(16,
+      ::grpc::Service::MarkMethodStreamed(17,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_ExecuteActorStateTransaction<BaseClass>::StreamedExecuteActorStateTransaction, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_ExecuteActorStateTransaction() override {
@@ -2146,7 +2416,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_InvokeActor() {
-      ::grpc::Service::MarkMethodStreamed(17,
+      ::grpc::Service::MarkMethodStreamed(18,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::InvokeActorRequest, ::dapr::proto::runtime::v1::InvokeActorResponse>(std::bind(&WithStreamedUnaryMethod_InvokeActor<BaseClass>::StreamedInvokeActor, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_InvokeActor() override {
@@ -2161,12 +2431,32 @@ class Dapr final {
     virtual ::grpc::Status StreamedInvokeActor(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::InvokeActorRequest,::dapr::proto::runtime::v1::InvokeActorResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_GetConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_GetConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodStreamed(19,
+        new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::GetConfigurationRequest, ::dapr::proto::runtime::v1::GetConfigurationResponse>(std::bind(&WithStreamedUnaryMethod_GetConfigurationAlpha1<BaseClass>::StreamedGetConfigurationAlpha1, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_GetConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status GetConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::GetConfigurationRequest* request, ::dapr::proto::runtime::v1::GetConfigurationResponse* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedGetConfigurationAlpha1(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::dapr::proto::runtime::v1::GetConfigurationRequest,::dapr::proto::runtime::v1::GetConfigurationResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_GetMetadata : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_GetMetadata() {
-      ::grpc::Service::MarkMethodStreamed(18,
+      ::grpc::Service::MarkMethodStreamed(21,
         new ::grpc::internal::StreamedUnaryHandler< ::google::protobuf::Empty, ::dapr::proto::runtime::v1::GetMetadataResponse>(std::bind(&WithStreamedUnaryMethod_GetMetadata<BaseClass>::StreamedGetMetadata, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_GetMetadata() override {
@@ -2186,7 +2476,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_SetMetadata() {
-      ::grpc::Service::MarkMethodStreamed(19,
+      ::grpc::Service::MarkMethodStreamed(22,
         new ::grpc::internal::StreamedUnaryHandler< ::dapr::proto::runtime::v1::SetMetadataRequest, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_SetMetadata<BaseClass>::StreamedSetMetadata, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_SetMetadata() override {
@@ -2206,7 +2496,7 @@ class Dapr final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_Shutdown() {
-      ::grpc::Service::MarkMethodStreamed(20,
+      ::grpc::Service::MarkMethodStreamed(23,
         new ::grpc::internal::StreamedUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(std::bind(&WithStreamedUnaryMethod_Shutdown<BaseClass>::StreamedShutdown, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_Shutdown() override {
@@ -2220,9 +2510,29 @@ class Dapr final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedShutdown(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
-  typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_QueryStateAlpha1<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetConfigurationAlpha1<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeConfigurationAlpha1 : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithSplitStreamingMethod_SubscribeConfigurationAlpha1() {
+      ::grpc::Service::MarkMethodStreamed(20,
+        new ::grpc::internal::SplitServerStreamingHandler< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest, ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>(std::bind(&WithSplitStreamingMethod_SubscribeConfigurationAlpha1<BaseClass>::StreamedSubscribeConfigurationAlpha1, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithSplitStreamingMethod_SubscribeConfigurationAlpha1() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeConfigurationAlpha1(::grpc::ServerContext* context, const ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* request, ::grpc::ServerWriter< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeConfigurationAlpha1(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest,::dapr::proto::runtime::v1::SubscribeConfigurationResponse>* server_split_streamer) = 0;
+  };
+  typedef WithSplitStreamingMethod_SubscribeConfigurationAlpha1<Service > SplitStreamedService;
+  typedef WithStreamedUnaryMethod_InvokeService<WithStreamedUnaryMethod_GetState<WithStreamedUnaryMethod_GetBulkState<WithStreamedUnaryMethod_SaveState<WithStreamedUnaryMethod_QueryStateAlpha1<WithStreamedUnaryMethod_DeleteState<WithStreamedUnaryMethod_DeleteBulkState<WithStreamedUnaryMethod_ExecuteStateTransaction<WithStreamedUnaryMethod_PublishEvent<WithStreamedUnaryMethod_InvokeBinding<WithStreamedUnaryMethod_GetSecret<WithStreamedUnaryMethod_GetBulkSecret<WithStreamedUnaryMethod_RegisterActorTimer<WithStreamedUnaryMethod_UnregisterActorTimer<WithStreamedUnaryMethod_RegisterActorReminder<WithStreamedUnaryMethod_UnregisterActorReminder<WithStreamedUnaryMethod_GetActorState<WithStreamedUnaryMethod_ExecuteActorStateTransaction<WithStreamedUnaryMethod_InvokeActor<WithStreamedUnaryMethod_GetConfigurationAlpha1<WithSplitStreamingMethod_SubscribeConfigurationAlpha1<WithStreamedUnaryMethod_GetMetadata<WithStreamedUnaryMethod_SetMetadata<WithStreamedUnaryMethod_Shutdown<Service > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace v1

--- a/src/dapr/proto/runtime/v1/dapr.pb.cc
+++ b/src/dapr/proto/runtime/v1/dapr.pb.cc
@@ -22,6 +22,7 @@
 namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto {
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_Etag;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_StateOptions;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_ConfigurationItem;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<2> scc_info_InvokeRequest;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto ::google::protobuf::internal::SCCInfo<3> scc_info_StateItem;
 }  // namespace protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto
@@ -32,6 +33,7 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2epr
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_ExecuteStateTransactionRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkSecretRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetBulkStateRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetConfigurationRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetMetadataResponse_ExtendedMetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_GetSecretResponse_DataEntry_DoNotUse;
@@ -40,8 +42,12 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2epr
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_InvokeBindingResponse_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_PublishEventRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateItem;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateRequest_MetadataEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateResponse_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_RegisteredComponents;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_SecretResponse_SecretsEntry_DoNotUse;
+extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_SubscribeConfigurationRequest_MetadataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_BulkStateItem;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_GetBulkSecretResponse_DataEntry_DoNotUse;
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto ::google::protobuf::internal::SCCInfo<1> scc_info_SecretResponse;
@@ -125,6 +131,31 @@ class SaveStateRequestDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<SaveStateRequest>
       _instance;
 } _SaveStateRequest_default_instance_;
+class QueryStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<QueryStateRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _QueryStateRequest_MetadataEntry_DoNotUse_default_instance_;
+class QueryStateRequestDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<QueryStateRequest>
+      _instance;
+} _QueryStateRequest_default_instance_;
+class QueryStateItemDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<QueryStateItem>
+      _instance;
+} _QueryStateItem_default_instance_;
+class QueryStateResponse_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<QueryStateResponse_MetadataEntry_DoNotUse>
+      _instance;
+} _QueryStateResponse_MetadataEntry_DoNotUse_default_instance_;
+class QueryStateResponseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<QueryStateResponse>
+      _instance;
+} _QueryStateResponse_default_instance_;
 class PublishEventRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<PublishEventRequest_MetadataEntry_DoNotUse>
@@ -295,6 +326,36 @@ class SetMetadataRequestDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<SetMetadataRequest>
       _instance;
 } _SetMetadataRequest_default_instance_;
+class GetConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetConfigurationRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _GetConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+class GetConfigurationRequestDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetConfigurationRequest>
+      _instance;
+} _GetConfigurationRequest_default_instance_;
+class GetConfigurationResponseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GetConfigurationResponse>
+      _instance;
+} _GetConfigurationResponse_default_instance_;
+class SubscribeConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SubscribeConfigurationRequest_MetadataEntry_DoNotUse>
+      _instance;
+} _SubscribeConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+class SubscribeConfigurationRequestDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SubscribeConfigurationRequest>
+      _instance;
+} _SubscribeConfigurationRequest_default_instance_;
+class SubscribeConfigurationResponseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<SubscribeConfigurationResponse>
+      _instance;
+} _SubscribeConfigurationResponse_default_instance_;
 }  // namespace v1
 }  // namespace runtime
 }  // namespace proto
@@ -501,6 +562,77 @@ static void InitDefaultsSaveStateRequest() {
 ::google::protobuf::internal::SCCInfo<1> scc_info_SaveStateRequest =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsSaveStateRequest}, {
       &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_StateItem.base,}};
+
+static void InitDefaultsQueryStateRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_QueryStateRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsQueryStateRequest_MetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsQueryStateRequest() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_QueryStateRequest_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::QueryStateRequest();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::QueryStateRequest::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_QueryStateRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsQueryStateRequest}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateRequest_MetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsQueryStateItem() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_QueryStateItem_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::QueryStateItem();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::QueryStateItem::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateItem =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsQueryStateItem}, {}};
+
+static void InitDefaultsQueryStateResponse_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_QueryStateResponse_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_QueryStateResponse_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsQueryStateResponse_MetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsQueryStateResponse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_QueryStateResponse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::QueryStateResponse();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::QueryStateResponse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<2> scc_info_QueryStateResponse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 2, InitDefaultsQueryStateResponse}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateItem.base,
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateResponse_MetadataEntry_DoNotUse.base,}};
 
 static void InitDefaultsPublishEventRequest_MetadataEntry_DoNotUse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -985,6 +1117,92 @@ static void InitDefaultsSetMetadataRequest() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_SetMetadataRequest =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsSetMetadataRequest}, {}};
 
+static void InitDefaultsGetConfigurationRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_GetConfigurationRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsGetConfigurationRequest_MetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsGetConfigurationRequest() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetConfigurationRequest_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetConfigurationRequest();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::GetConfigurationRequest::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_GetConfigurationRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetConfigurationRequest}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetConfigurationRequest_MetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsGetConfigurationResponse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_GetConfigurationResponse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::GetConfigurationResponse();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::GetConfigurationResponse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_GetConfigurationResponse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsGetConfigurationResponse}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_ConfigurationItem.base,}};
+
+static void InitDefaultsSubscribeConfigurationRequest_MetadataEntry_DoNotUse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SubscribeConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse();
+  }
+  ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_SubscribeConfigurationRequest_MetadataEntry_DoNotUse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsSubscribeConfigurationRequest_MetadataEntry_DoNotUse}, {}};
+
+static void InitDefaultsSubscribeConfigurationRequest() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SubscribeConfigurationRequest_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SubscribeConfigurationRequest();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::SubscribeConfigurationRequest::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_SubscribeConfigurationRequest =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsSubscribeConfigurationRequest}, {
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SubscribeConfigurationRequest_MetadataEntry_DoNotUse.base,}};
+
+static void InitDefaultsSubscribeConfigurationResponse() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::dapr::proto::runtime::v1::_SubscribeConfigurationResponse_default_instance_;
+    new (ptr) ::dapr::proto::runtime::v1::SubscribeConfigurationResponse();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::dapr::proto::runtime::v1::SubscribeConfigurationResponse::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<1> scc_info_SubscribeConfigurationResponse =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 1, InitDefaultsSubscribeConfigurationResponse}, {
+      &protobuf_dapr_2fproto_2fcommon_2fv1_2fcommon_2eproto::scc_info_ConfigurationItem.base,}};
+
 void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeServiceRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_GetStateRequest_MetadataEntry_DoNotUse.base);
@@ -1000,6 +1218,11 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_DeleteStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_DeleteBulkStateRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_SaveStateRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_QueryStateRequest_MetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_QueryStateRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_QueryStateItem.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_QueryStateResponse_MetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_QueryStateResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_PublishEventRequest_MetadataEntry_DoNotUse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_PublishEventRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_InvokeBindingRequest_MetadataEntry_DoNotUse.base);
@@ -1034,9 +1257,15 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_ActiveActorsCount.base);
   ::google::protobuf::internal::InitSCC(&scc_info_RegisteredComponents.base);
   ::google::protobuf::internal::InitSCC(&scc_info_SetMetadataRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetConfigurationRequest_MetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetConfigurationRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_GetConfigurationResponse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SubscribeConfigurationRequest_MetadataEntry_DoNotUse.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SubscribeConfigurationRequest.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_SubscribeConfigurationResponse.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[48];
+::google::protobuf::Metadata file_level_metadata[59];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -1157,6 +1386,49 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SaveStateRequest, store_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SaveStateRequest, states_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest, store_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest, query_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateRequest, metadata_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateItem, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateItem, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateItem, data_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateItem, etag_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateItem, error_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse, results_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse, token_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::QueryStateResponse, metadata_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse, _has_bits_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1324,6 +1596,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorTimerRequest, period_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorTimerRequest, callback_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorTimerRequest, data_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorTimerRequest, ttl_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::UnregisterActorTimerRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1343,6 +1616,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorReminderRequest, due_time_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorReminderRequest, period_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorReminderRequest, data_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::RegisterActorReminderRequest, ttl_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::UnregisterActorReminderRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -1436,6 +1710,52 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SetMetadataRequest, key_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SetMetadataRequest, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest, store_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest, keys_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationRequest, metadata_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::GetConfigurationResponse, items_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest, store_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest, keys_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationRequest, metadata_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::dapr::proto::runtime::v1::SubscribeConfigurationResponse, items_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::dapr::proto::runtime::v1::InvokeServiceRequest)},
@@ -1452,40 +1772,51 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 94, -1, sizeof(::dapr::proto::runtime::v1::DeleteStateRequest)},
   { 104, -1, sizeof(::dapr::proto::runtime::v1::DeleteBulkStateRequest)},
   { 111, -1, sizeof(::dapr::proto::runtime::v1::SaveStateRequest)},
-  { 118, 125, sizeof(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse)},
-  { 127, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
-  { 137, 144, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
-  { 146, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
-  { 155, 162, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
-  { 164, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
-  { 171, 178, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
-  { 180, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
-  { 188, 195, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
-  { 197, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
-  { 203, 210, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest_MetadataEntry_DoNotUse)},
-  { 212, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest)},
-  { 219, 226, sizeof(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse)},
-  { 228, -1, sizeof(::dapr::proto::runtime::v1::SecretResponse)},
-  { 234, 241, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse)},
-  { 243, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse)},
-  { 249, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
-  { 256, 263, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
-  { 265, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
-  { 273, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorTimerRequest)},
-  { 285, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorTimerRequest)},
-  { 293, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorReminderRequest)},
-  { 304, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorReminderRequest)},
-  { 312, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateRequest)},
-  { 320, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateResponse)},
-  { 326, -1, sizeof(::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest)},
-  { 334, -1, sizeof(::dapr::proto::runtime::v1::TransactionalActorStateOperation)},
-  { 342, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorRequest)},
-  { 351, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorResponse)},
-  { 357, 364, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse)},
-  { 366, -1, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse)},
-  { 375, -1, sizeof(::dapr::proto::runtime::v1::ActiveActorsCount)},
-  { 382, -1, sizeof(::dapr::proto::runtime::v1::RegisteredComponents)},
-  { 390, -1, sizeof(::dapr::proto::runtime::v1::SetMetadataRequest)},
+  { 118, 125, sizeof(::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse)},
+  { 127, -1, sizeof(::dapr::proto::runtime::v1::QueryStateRequest)},
+  { 135, -1, sizeof(::dapr::proto::runtime::v1::QueryStateItem)},
+  { 144, 151, sizeof(::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse)},
+  { 153, -1, sizeof(::dapr::proto::runtime::v1::QueryStateResponse)},
+  { 161, 168, sizeof(::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse)},
+  { 170, -1, sizeof(::dapr::proto::runtime::v1::PublishEventRequest)},
+  { 180, 187, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest_MetadataEntry_DoNotUse)},
+  { 189, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingRequest)},
+  { 198, 205, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNotUse)},
+  { 207, -1, sizeof(::dapr::proto::runtime::v1::InvokeBindingResponse)},
+  { 214, 221, sizeof(::dapr::proto::runtime::v1::GetSecretRequest_MetadataEntry_DoNotUse)},
+  { 223, -1, sizeof(::dapr::proto::runtime::v1::GetSecretRequest)},
+  { 231, 238, sizeof(::dapr::proto::runtime::v1::GetSecretResponse_DataEntry_DoNotUse)},
+  { 240, -1, sizeof(::dapr::proto::runtime::v1::GetSecretResponse)},
+  { 246, 253, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest_MetadataEntry_DoNotUse)},
+  { 255, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretRequest)},
+  { 262, 269, sizeof(::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse)},
+  { 271, -1, sizeof(::dapr::proto::runtime::v1::SecretResponse)},
+  { 277, 284, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse)},
+  { 286, -1, sizeof(::dapr::proto::runtime::v1::GetBulkSecretResponse)},
+  { 292, -1, sizeof(::dapr::proto::runtime::v1::TransactionalStateOperation)},
+  { 299, 306, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest_MetadataEntry_DoNotUse)},
+  { 308, -1, sizeof(::dapr::proto::runtime::v1::ExecuteStateTransactionRequest)},
+  { 316, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorTimerRequest)},
+  { 329, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorTimerRequest)},
+  { 337, -1, sizeof(::dapr::proto::runtime::v1::RegisterActorReminderRequest)},
+  { 349, -1, sizeof(::dapr::proto::runtime::v1::UnregisterActorReminderRequest)},
+  { 357, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateRequest)},
+  { 365, -1, sizeof(::dapr::proto::runtime::v1::GetActorStateResponse)},
+  { 371, -1, sizeof(::dapr::proto::runtime::v1::ExecuteActorStateTransactionRequest)},
+  { 379, -1, sizeof(::dapr::proto::runtime::v1::TransactionalActorStateOperation)},
+  { 387, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorRequest)},
+  { 396, -1, sizeof(::dapr::proto::runtime::v1::InvokeActorResponse)},
+  { 402, 409, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse)},
+  { 411, -1, sizeof(::dapr::proto::runtime::v1::GetMetadataResponse)},
+  { 420, -1, sizeof(::dapr::proto::runtime::v1::ActiveActorsCount)},
+  { 427, -1, sizeof(::dapr::proto::runtime::v1::RegisteredComponents)},
+  { 435, -1, sizeof(::dapr::proto::runtime::v1::SetMetadataRequest)},
+  { 442, 449, sizeof(::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse)},
+  { 451, -1, sizeof(::dapr::proto::runtime::v1::GetConfigurationRequest)},
+  { 459, -1, sizeof(::dapr::proto::runtime::v1::GetConfigurationResponse)},
+  { 465, 472, sizeof(::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse)},
+  { 474, -1, sizeof(::dapr::proto::runtime::v1::SubscribeConfigurationRequest)},
+  { 482, -1, sizeof(::dapr::proto::runtime::v1::SubscribeConfigurationResponse)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -1503,6 +1834,11 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_DeleteBulkStateRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SaveStateRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_QueryStateRequest_MetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_QueryStateRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_QueryStateItem_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_QueryStateResponse_MetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_QueryStateResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_PublishEventRequest_MetadataEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_PublishEventRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_InvokeBindingRequest_MetadataEntry_DoNotUse_default_instance_),
@@ -1537,6 +1873,12 @@ static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_ActiveActorsCount_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_RegisteredComponents_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SetMetadataRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetConfigurationRequest_MetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetConfigurationRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_GetConfigurationResponse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SubscribeConfigurationRequest_MetadataEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SubscribeConfigurationRequest_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::dapr::proto::runtime::v1::_SubscribeConfigurationResponse_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -1554,7 +1896,7 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 48);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 59);
 }
 
 void AddDescriptorsImpl() {
@@ -1599,145 +1941,181 @@ void AddDescriptorsImpl() {
       "e_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037.dapr.prot"
       "o.common.v1.StateItem\"W\n\020SaveStateReques"
       "t\022\022\n\nstore_name\030\001 \001(\t\022/\n\006states\030\002 \003(\0132\037."
-      "dapr.proto.common.v1.StateItem\"\337\001\n\023Publi"
-      "shEventRequest\022\023\n\013pubsub_name\030\001 \001(\t\022\r\n\005t"
-      "opic\030\002 \001(\t\022\014\n\004data\030\003 \001(\014\022\031\n\021data_content"
-      "_type\030\004 \001(\t\022J\n\010metadata\030\005 \003(\01328.dapr.pro"
-      "to.runtime.v1.PublishEventRequest.Metada"
-      "taEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
-      "\005value\030\002 \001(\t:\0028\001\"\303\001\n\024InvokeBindingReques"
-      "t\022\014\n\004name\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022K\n\010metadat"
-      "a\030\003 \003(\01329.dapr.proto.runtime.v1.InvokeBi"
-      "ndingRequest.MetadataEntry\022\021\n\toperation\030"
-      "\004 \001(\t\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v"
-      "alue\030\002 \001(\t:\0028\001\"\244\001\n\025InvokeBindingResponse"
-      "\022\014\n\004data\030\001 \001(\014\022L\n\010metadata\030\002 \003(\0132:.dapr."
-      "proto.runtime.v1.InvokeBindingResponse.M"
-      "etadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001"
-      "(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\255\001\n\020GetSecretReque"
-      "st\022\022\n\nstore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022G\n\010m"
-      "etadata\030\003 \003(\01325.dapr.proto.runtime.v1.Ge"
-      "tSecretRequest.MetadataEntry\032/\n\rMetadata"
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001"
-      "\n\021GetSecretResponse\022@\n\004data\030\001 \003(\01322.dapr"
-      ".proto.runtime.v1.GetSecretResponse.Data"
-      "Entry\032+\n\tDataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
-      "\030\002 \001(\t:\0028\001\"\250\001\n\024GetBulkSecretRequest\022\022\n\ns"
-      "tore_name\030\001 \001(\t\022K\n\010metadata\030\002 \003(\01329.dapr"
-      ".proto.runtime.v1.GetBulkSecretRequest.M"
-      "etadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001"
-      "(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\205\001\n\016SecretResponse"
-      "\022C\n\007secrets\030\001 \003(\01322.dapr.proto.runtime.v"
-      "1.SecretResponse.SecretsEntry\032.\n\014Secrets"
-      "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\261\001"
-      "\n\025GetBulkSecretResponse\022D\n\004data\030\001 \003(\01326."
-      "dapr.proto.runtime.v1.GetBulkSecretRespo"
-      "nse.DataEntry\032R\n\tDataEntry\022\013\n\003key\030\001 \001(\t\022"
-      "4\n\005value\030\002 \001(\0132%.dapr.proto.runtime.v1.S"
-      "ecretResponse:\0028\001\"f\n\033TransactionalStateO"
-      "peration\022\025\n\roperationType\030\001 \001(\t\0220\n\007reque"
-      "st\030\002 \001(\0132\037.dapr.proto.common.v1.StateIte"
-      "m\"\203\002\n\036ExecuteStateTransactionRequest\022\021\n\t"
-      "storeName\030\001 \001(\t\022F\n\noperations\030\002 \003(\01322.da"
-      "pr.proto.runtime.v1.TransactionalStateOp"
-      "eration\022U\n\010metadata\030\003 \003(\0132C.dapr.proto.r"
-      "untime.v1.ExecuteStateTransactionRequest"
-      ".MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001"
-      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\221\001\n\031RegisterActo"
-      "rTimerRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010act"
-      "or_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 "
-      "\001(\t\022\016\n\006period\030\005 \001(\t\022\020\n\010callback\030\006 \001(\t\022\014\n"
-      "\004data\030\007 \001(\014\"Q\n\033UnregisterActorTimerReque"
-      "st\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t"
-      "\022\014\n\004name\030\003 \001(\t\"\202\001\n\034RegisterActorReminder"
+      "dapr.proto.common.v1.StateItem\"\261\001\n\021Query"
+      "StateRequest\022\022\n\nstore_name\030\001 \001(\t\022\r\n\005quer"
+      "y\030\002 \001(\t\022H\n\010metadata\030\003 \003(\01326.dapr.proto.r"
+      "untime.v1.QueryStateRequest.MetadataEntr"
+      "y\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+      "\030\002 \001(\t:\0028\001\"H\n\016QueryStateItem\022\013\n\003key\030\001 \001("
+      "\t\022\014\n\004data\030\002 \001(\014\022\014\n\004etag\030\003 \001(\t\022\r\n\005error\030\004"
+      " \001(\t\"\327\001\n\022QueryStateResponse\0226\n\007results\030\001"
+      " \003(\0132%.dapr.proto.runtime.v1.QueryStateI"
+      "tem\022\r\n\005token\030\002 \001(\t\022I\n\010metadata\030\003 \003(\01327.d"
+      "apr.proto.runtime.v1.QueryStateResponse."
+      "MetadataEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 "
+      "\001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\337\001\n\023PublishEventR"
+      "equest\022\023\n\013pubsub_name\030\001 \001(\t\022\r\n\005topic\030\002 \001"
+      "(\t\022\014\n\004data\030\003 \001(\014\022\031\n\021data_content_type\030\004 "
+      "\001(\t\022J\n\010metadata\030\005 \003(\01328.dapr.proto.runti"
+      "me.v1.PublishEventRequest.MetadataEntry\032"
+      "/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002"
+      " \001(\t:\0028\001\"\303\001\n\024InvokeBindingRequest\022\014\n\004nam"
+      "e\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022K\n\010metadata\030\003 \003(\0132"
+      "9.dapr.proto.runtime.v1.InvokeBindingReq"
+      "uest.MetadataEntry\022\021\n\toperation\030\004 \001(\t\032/\n"
+      "\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001"
+      "(\t:\0028\001\"\244\001\n\025InvokeBindingResponse\022\014\n\004data"
+      "\030\001 \001(\014\022L\n\010metadata\030\002 \003(\0132:.dapr.proto.ru"
+      "ntime.v1.InvokeBindingResponse.MetadataE"
+      "ntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va"
+      "lue\030\002 \001(\t:\0028\001\"\255\001\n\020GetSecretRequest\022\022\n\nst"
+      "ore_name\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022G\n\010metadata\030"
+      "\003 \003(\01325.dapr.proto.runtime.v1.GetSecretR"
+      "equest.MetadataEntry\032/\n\rMetadataEntry\022\013\n"
+      "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001\n\021GetSec"
+      "retResponse\022@\n\004data\030\001 \003(\01322.dapr.proto.r"
+      "untime.v1.GetSecretResponse.DataEntry\032+\n"
+      "\tDataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
+      "8\001\"\250\001\n\024GetBulkSecretRequest\022\022\n\nstore_nam"
+      "e\030\001 \001(\t\022K\n\010metadata\030\002 \003(\01329.dapr.proto.r"
+      "untime.v1.GetBulkSecretRequest.MetadataE"
+      "ntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va"
+      "lue\030\002 \001(\t:\0028\001\"\205\001\n\016SecretResponse\022C\n\007secr"
+      "ets\030\001 \003(\01322.dapr.proto.runtime.v1.Secret"
+      "Response.SecretsEntry\032.\n\014SecretsEntry\022\013\n"
+      "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\261\001\n\025GetBul"
+      "kSecretResponse\022D\n\004data\030\001 \003(\01326.dapr.pro"
+      "to.runtime.v1.GetBulkSecretResponse.Data"
+      "Entry\032R\n\tDataEntry\022\013\n\003key\030\001 \001(\t\0224\n\005value"
+      "\030\002 \001(\0132%.dapr.proto.runtime.v1.SecretRes"
+      "ponse:\0028\001\"f\n\033TransactionalStateOperation"
+      "\022\025\n\roperationType\030\001 \001(\t\0220\n\007request\030\002 \001(\013"
+      "2\037.dapr.proto.common.v1.StateItem\"\203\002\n\036Ex"
+      "ecuteStateTransactionRequest\022\021\n\tstoreNam"
+      "e\030\001 \001(\t\022F\n\noperations\030\002 \003(\01322.dapr.proto"
+      ".runtime.v1.TransactionalStateOperation\022"
+      "U\n\010metadata\030\003 \003(\0132C.dapr.proto.runtime.v"
+      "1.ExecuteStateTransactionRequest.Metadat"
+      "aEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005"
+      "value\030\002 \001(\t:\0028\001\"\236\001\n\031RegisterActorTimerRe"
+      "quest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 "
+      "\001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 \001(\t\022\016\n\006p"
+      "eriod\030\005 \001(\t\022\020\n\010callback\030\006 \001(\t\022\014\n\004data\030\007 "
+      "\001(\014\022\013\n\003ttl\030\010 \001(\t\"Q\n\033UnregisterActorTimer"
       "Request\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030"
-      "\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 \001(\t\022\016\n"
-      "\006period\030\005 \001(\t\022\014\n\004data\030\006 \001(\014\"T\n\036Unregiste"
-      "rActorReminderRequest\022\022\n\nactor_type\030\001 \001("
-      "\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\"I\n\024Get"
-      "ActorStateRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n"
-      "\010actor_id\030\002 \001(\t\022\013\n\003key\030\003 \001(\t\"%\n\025GetActor"
-      "StateResponse\022\014\n\004data\030\001 \001(\014\"\230\001\n#ExecuteA"
-      "ctorStateTransactionRequest\022\022\n\nactor_typ"
-      "e\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022K\n\noperations\030"
-      "\003 \003(\01327.dapr.proto.runtime.v1.Transactio"
-      "nalActorStateOperation\"k\n TransactionalA"
-      "ctorStateOperation\022\025\n\roperationType\030\001 \001("
-      "\t\022\013\n\003key\030\002 \001(\t\022#\n\005value\030\003 \001(\0132\024.google.p"
-      "rotobuf.Any\"X\n\022InvokeActorRequest\022\022\n\nact"
-      "or_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\016\n\006metho"
-      "d\030\003 \001(\t\022\014\n\004data\030\004 \001(\014\"#\n\023InvokeActorResp"
-      "onse\022\014\n\004data\030\001 \001(\014\"\312\002\n\023GetMetadataRespon"
-      "se\022\n\n\002id\030\001 \001(\t\022E\n\023active_actors_count\030\002 "
-      "\003(\0132(.dapr.proto.runtime.v1.ActiveActors"
-      "Count\022J\n\025registered_components\030\003 \003(\0132+.d"
-      "apr.proto.runtime.v1.RegisteredComponent"
-      "s\022[\n\021extended_metadata\030\004 \003(\0132@.dapr.prot"
-      "o.runtime.v1.GetMetadataResponse.Extende"
-      "dMetadataEntry\0327\n\025ExtendedMetadataEntry\022"
-      "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"0\n\021Activ"
-      "eActorsCount\022\014\n\004type\030\001 \001(\t\022\r\n\005count\030\002 \001("
-      "\005\"C\n\024RegisteredComponents\022\014\n\004name\030\001 \001(\t\022"
-      "\014\n\004type\030\002 \001(\t\022\017\n\007version\030\003 \001(\t\"0\n\022SetMet"
-      "adataRequest\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t"
-      "2\205\020\n\004Dapr\022d\n\rInvokeService\022+.dapr.proto."
-      "runtime.v1.InvokeServiceRequest\032$.dapr.p"
-      "roto.common.v1.InvokeResponse\"\000\022]\n\010GetSt"
-      "ate\022&.dapr.proto.runtime.v1.GetStateRequ"
-      "est\032\'.dapr.proto.runtime.v1.GetStateResp"
-      "onse\"\000\022i\n\014GetBulkState\022*.dapr.proto.runt"
-      "ime.v1.GetBulkStateRequest\032+.dapr.proto."
-      "runtime.v1.GetBulkStateResponse\"\000\022N\n\tSav"
-      "eState\022\'.dapr.proto.runtime.v1.SaveState"
-      "Request\032\026.google.protobuf.Empty\"\000\022R\n\013Del"
-      "eteState\022).dapr.proto.runtime.v1.DeleteS"
-      "tateRequest\032\026.google.protobuf.Empty\"\000\022Z\n"
-      "\017DeleteBulkState\022-.dapr.proto.runtime.v1"
-      ".DeleteBulkStateRequest\032\026.google.protobu"
-      "f.Empty\"\000\022j\n\027ExecuteStateTransaction\0225.d"
-      "apr.proto.runtime.v1.ExecuteStateTransac"
-      "tionRequest\032\026.google.protobuf.Empty\"\000\022T\n"
-      "\014PublishEvent\022*.dapr.proto.runtime.v1.Pu"
-      "blishEventRequest\032\026.google.protobuf.Empt"
-      "y\"\000\022l\n\rInvokeBinding\022+.dapr.proto.runtim"
-      "e.v1.InvokeBindingRequest\032,.dapr.proto.r"
-      "untime.v1.InvokeBindingResponse\"\000\022`\n\tGet"
-      "Secret\022\'.dapr.proto.runtime.v1.GetSecret"
-      "Request\032(.dapr.proto.runtime.v1.GetSecre"
-      "tResponse\"\000\022l\n\rGetBulkSecret\022+.dapr.prot"
-      "o.runtime.v1.GetBulkSecretRequest\032,.dapr"
-      ".proto.runtime.v1.GetBulkSecretResponse\""
-      "\000\022`\n\022RegisterActorTimer\0220.dapr.proto.run"
-      "time.v1.RegisterActorTimerRequest\032\026.goog"
-      "le.protobuf.Empty\"\000\022d\n\024UnregisterActorTi"
-      "mer\0222.dapr.proto.runtime.v1.UnregisterAc"
-      "torTimerRequest\032\026.google.protobuf.Empty\""
-      "\000\022f\n\025RegisterActorReminder\0223.dapr.proto."
-      "runtime.v1.RegisterActorReminderRequest\032"
-      "\026.google.protobuf.Empty\"\000\022j\n\027UnregisterA"
-      "ctorReminder\0225.dapr.proto.runtime.v1.Unr"
-      "egisterActorReminderRequest\032\026.google.pro"
-      "tobuf.Empty\"\000\022l\n\rGetActorState\022+.dapr.pr"
-      "oto.runtime.v1.GetActorStateRequest\032,.da"
-      "pr.proto.runtime.v1.GetActorStateRespons"
-      "e\"\000\022t\n\034ExecuteActorStateTransaction\022:.da"
-      "pr.proto.runtime.v1.ExecuteActorStateTra"
-      "nsactionRequest\032\026.google.protobuf.Empty\""
-      "\000\022f\n\013InvokeActor\022).dapr.proto.runtime.v1"
-      ".InvokeActorRequest\032*.dapr.proto.runtime"
-      ".v1.InvokeActorResponse\"\000\022S\n\013GetMetadata"
-      "\022\026.google.protobuf.Empty\032*.dapr.proto.ru"
-      "ntime.v1.GetMetadataResponse\"\000\022R\n\013SetMet"
-      "adata\022).dapr.proto.runtime.v1.SetMetadat"
-      "aRequest\032\026.google.protobuf.Empty\"\000\022<\n\010Sh"
-      "utdown\022\026.google.protobuf.Empty\032\026.google."
-      "protobuf.Empty\"\000Bi\n\nio.dapr.v1B\nDaprProt"
-      "osZ1github.com/dapr/dapr/pkg/proto/runti"
-      "me/v1;runtime\252\002\033Dapr.Client.Autogen.Grpc"
-      ".v1b\006proto3"
+      "\002 \001(\t\022\014\n\004name\030\003 \001(\t\"\217\001\n\034RegisterActorRem"
+      "inderRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010acto"
+      "r_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\020\n\010due_time\030\004 \001"
+      "(\t\022\016\n\006period\030\005 \001(\t\022\014\n\004data\030\006 \001(\014\022\013\n\003ttl\030"
+      "\007 \001(\t\"T\n\036UnregisterActorReminderRequest\022"
+      "\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\014\n"
+      "\004name\030\003 \001(\t\"I\n\024GetActorStateRequest\022\022\n\na"
+      "ctor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 \001(\t\022\013\n\003key"
+      "\030\003 \001(\t\"%\n\025GetActorStateResponse\022\014\n\004data\030"
+      "\001 \001(\014\"\230\001\n#ExecuteActorStateTransactionRe"
+      "quest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor_id\030\002 "
+      "\001(\t\022K\n\noperations\030\003 \003(\01327.dapr.proto.run"
+      "time.v1.TransactionalActorStateOperation"
+      "\"k\n TransactionalActorStateOperation\022\025\n\r"
+      "operationType\030\001 \001(\t\022\013\n\003key\030\002 \001(\t\022#\n\005valu"
+      "e\030\003 \001(\0132\024.google.protobuf.Any\"X\n\022InvokeA"
+      "ctorRequest\022\022\n\nactor_type\030\001 \001(\t\022\020\n\010actor"
+      "_id\030\002 \001(\t\022\016\n\006method\030\003 \001(\t\022\014\n\004data\030\004 \001(\014\""
+      "#\n\023InvokeActorResponse\022\014\n\004data\030\001 \001(\014\"\312\002\n"
+      "\023GetMetadataResponse\022\n\n\002id\030\001 \001(\t\022E\n\023acti"
+      "ve_actors_count\030\002 \003(\0132(.dapr.proto.runti"
+      "me.v1.ActiveActorsCount\022J\n\025registered_co"
+      "mponents\030\003 \003(\0132+.dapr.proto.runtime.v1.R"
+      "egisteredComponents\022[\n\021extended_metadata"
+      "\030\004 \003(\0132@.dapr.proto.runtime.v1.GetMetada"
+      "taResponse.ExtendedMetadataEntry\0327\n\025Exte"
+      "ndedMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030"
+      "\002 \001(\t:\0028\001\"0\n\021ActiveActorsCount\022\014\n\004type\030\001"
+      " \001(\t\022\r\n\005count\030\002 \001(\005\"C\n\024RegisteredCompone"
+      "nts\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\017\n\007versi"
+      "on\030\003 \001(\t\"0\n\022SetMetadataRequest\022\013\n\003key\030\001 "
+      "\001(\t\022\r\n\005value\030\002 \001(\t\"\274\001\n\027GetConfigurationR"
+      "equest\022\022\n\nstore_name\030\001 \001(\t\022\014\n\004keys\030\002 \003(\t"
+      "\022N\n\010metadata\030\003 \003(\0132<.dapr.proto.runtime."
+      "v1.GetConfigurationRequest.MetadataEntry"
+      "\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030"
+      "\002 \001(\t:\0028\001\"R\n\030GetConfigurationResponse\0226\n"
+      "\005items\030\001 \003(\0132\'.dapr.proto.common.v1.Conf"
+      "igurationItem\"\310\001\n\035SubscribeConfiguration"
+      "Request\022\022\n\nstore_name\030\001 \001(\t\022\014\n\004keys\030\002 \003("
+      "\t\022T\n\010metadata\030\003 \003(\0132B.dapr.proto.runtime"
+      ".v1.SubscribeConfigurationRequest.Metada"
+      "taEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
+      "\005value\030\002 \001(\t:\0028\001\"X\n\036SubscribeConfigurati"
+      "onResponse\0226\n\005items\030\001 \003(\0132\'.dapr.proto.c"
+      "ommon.v1.ConfigurationItem2\377\022\n\004Dapr\022d\n\rI"
+      "nvokeService\022+.dapr.proto.runtime.v1.Inv"
+      "okeServiceRequest\032$.dapr.proto.common.v1"
+      ".InvokeResponse\"\000\022]\n\010GetState\022&.dapr.pro"
+      "to.runtime.v1.GetStateRequest\032\'.dapr.pro"
+      "to.runtime.v1.GetStateResponse\"\000\022i\n\014GetB"
+      "ulkState\022*.dapr.proto.runtime.v1.GetBulk"
+      "StateRequest\032+.dapr.proto.runtime.v1.Get"
+      "BulkStateResponse\"\000\022N\n\tSaveState\022\'.dapr."
+      "proto.runtime.v1.SaveStateRequest\032\026.goog"
+      "le.protobuf.Empty\"\000\022i\n\020QueryStateAlpha1\022"
+      "(.dapr.proto.runtime.v1.QueryStateReques"
+      "t\032).dapr.proto.runtime.v1.QueryStateResp"
+      "onse\"\000\022R\n\013DeleteState\022).dapr.proto.runti"
+      "me.v1.DeleteStateRequest\032\026.google.protob"
+      "uf.Empty\"\000\022Z\n\017DeleteBulkState\022-.dapr.pro"
+      "to.runtime.v1.DeleteBulkStateRequest\032\026.g"
+      "oogle.protobuf.Empty\"\000\022j\n\027ExecuteStateTr"
+      "ansaction\0225.dapr.proto.runtime.v1.Execut"
+      "eStateTransactionRequest\032\026.google.protob"
+      "uf.Empty\"\000\022T\n\014PublishEvent\022*.dapr.proto."
+      "runtime.v1.PublishEventRequest\032\026.google."
+      "protobuf.Empty\"\000\022l\n\rInvokeBinding\022+.dapr"
+      ".proto.runtime.v1.InvokeBindingRequest\032,"
+      ".dapr.proto.runtime.v1.InvokeBindingResp"
+      "onse\"\000\022`\n\tGetSecret\022\'.dapr.proto.runtime"
+      ".v1.GetSecretRequest\032(.dapr.proto.runtim"
+      "e.v1.GetSecretResponse\"\000\022l\n\rGetBulkSecre"
+      "t\022+.dapr.proto.runtime.v1.GetBulkSecretR"
+      "equest\032,.dapr.proto.runtime.v1.GetBulkSe"
+      "cretResponse\"\000\022`\n\022RegisterActorTimer\0220.d"
+      "apr.proto.runtime.v1.RegisterActorTimerR"
+      "equest\032\026.google.protobuf.Empty\"\000\022d\n\024Unre"
+      "gisterActorTimer\0222.dapr.proto.runtime.v1"
+      ".UnregisterActorTimerRequest\032\026.google.pr"
+      "otobuf.Empty\"\000\022f\n\025RegisterActorReminder\022"
+      "3.dapr.proto.runtime.v1.RegisterActorRem"
+      "inderRequest\032\026.google.protobuf.Empty\"\000\022j"
+      "\n\027UnregisterActorReminder\0225.dapr.proto.r"
+      "untime.v1.UnregisterActorReminderRequest"
+      "\032\026.google.protobuf.Empty\"\000\022l\n\rGetActorSt"
+      "ate\022+.dapr.proto.runtime.v1.GetActorStat"
+      "eRequest\032,.dapr.proto.runtime.v1.GetActo"
+      "rStateResponse\"\000\022t\n\034ExecuteActorStateTra"
+      "nsaction\022:.dapr.proto.runtime.v1.Execute"
+      "ActorStateTransactionRequest\032\026.google.pr"
+      "otobuf.Empty\"\000\022f\n\013InvokeActor\022).dapr.pro"
+      "to.runtime.v1.InvokeActorRequest\032*.dapr."
+      "proto.runtime.v1.InvokeActorResponse\"\000\022{"
+      "\n\026GetConfigurationAlpha1\022..dapr.proto.ru"
+      "ntime.v1.GetConfigurationRequest\032/.dapr."
+      "proto.runtime.v1.GetConfigurationRespons"
+      "e\"\000\022\217\001\n\034SubscribeConfigurationAlpha1\0224.d"
+      "apr.proto.runtime.v1.SubscribeConfigurat"
+      "ionRequest\0325.dapr.proto.runtime.v1.Subsc"
+      "ribeConfigurationResponse\"\0000\001\022S\n\013GetMeta"
+      "data\022\026.google.protobuf.Empty\032*.dapr.prot"
+      "o.runtime.v1.GetMetadataResponse\"\000\022R\n\013Se"
+      "tMetadata\022).dapr.proto.runtime.v1.SetMet"
+      "adataRequest\032\026.google.protobuf.Empty\"\000\022<"
+      "\n\010Shutdown\022\026.google.protobuf.Empty\032\026.goo"
+      "gle.protobuf.Empty\"\000Bi\n\nio.dapr.v1B\nDapr"
+      "ProtosZ1github.com/dapr/dapr/pkg/proto/r"
+      "untime/v1;runtime\252\002\033Dapr.Client.Autogen."
+      "Grpc.v1b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 6971);
+      descriptor, 8415);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "dapr/proto/runtime/v1/dapr.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fprotobuf_2fany_2eproto::AddDescriptors();
@@ -5512,6 +5890,1343 @@ void SaveStateRequest::InternalSwap(SaveStateRequest* other) {
 
 // ===================================================================
 
+QueryStateRequest_MetadataEntry_DoNotUse::QueryStateRequest_MetadataEntry_DoNotUse() {}
+QueryStateRequest_MetadataEntry_DoNotUse::QueryStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void QueryStateRequest_MetadataEntry_DoNotUse::MergeFrom(const QueryStateRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata QueryStateRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[14];
+}
+void QueryStateRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void QueryStateRequest::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int QueryStateRequest::kStoreNameFieldNumber;
+const int QueryStateRequest::kQueryFieldNumber;
+const int QueryStateRequest::kMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+QueryStateRequest::QueryStateRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateRequest.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.QueryStateRequest)
+}
+QueryStateRequest::QueryStateRequest(const QueryStateRequest& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.store_name().size() > 0) {
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+  query_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.query().size() > 0) {
+    query_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.query_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.QueryStateRequest)
+}
+
+void QueryStateRequest::SharedCtor() {
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  query_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+QueryStateRequest::~QueryStateRequest() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.QueryStateRequest)
+  SharedDtor();
+}
+
+void QueryStateRequest::SharedDtor() {
+  store_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  query_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void QueryStateRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* QueryStateRequest::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const QueryStateRequest& QueryStateRequest::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateRequest.base);
+  return *internal_default_instance();
+}
+
+
+void QueryStateRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.QueryStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  metadata_.Clear();
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  query_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool QueryStateRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.QueryStateRequest)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string store_name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_store_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->store_name().data(), static_cast<int>(this->store_name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateRequest.store_name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string query = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_query()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->query().data(), static_cast<int>(this->query().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateRequest.query"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> metadata = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          QueryStateRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              QueryStateRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.QueryStateRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.QueryStateRequest)
+  return false;
+#undef DO_
+}
+
+void QueryStateRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.QueryStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateRequest.store_name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->store_name(), output);
+  }
+
+  // string query = 2;
+  if (this->query().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->query().data(), static_cast<int>(this->query().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateRequest.query");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->query(), output);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<QueryStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<QueryStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.QueryStateRequest)
+}
+
+::google::protobuf::uint8* QueryStateRequest::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.QueryStateRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateRequest.store_name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->store_name(), target);
+  }
+
+  // string query = 2;
+  if (this->query().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->query().data(), static_cast<int>(this->query().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateRequest.query");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->query(), target);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<QueryStateRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<QueryStateRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.QueryStateRequest)
+  return target;
+}
+
+size_t QueryStateRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.QueryStateRequest)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // map<string, string> metadata = 3;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<QueryStateRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->store_name());
+  }
+
+  // string query = 2;
+  if (this->query().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->query());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void QueryStateRequest::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.QueryStateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const QueryStateRequest* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const QueryStateRequest>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.QueryStateRequest)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.QueryStateRequest)
+    MergeFrom(*source);
+  }
+}
+
+void QueryStateRequest::MergeFrom(const QueryStateRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.QueryStateRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  metadata_.MergeFrom(from.metadata_);
+  if (from.store_name().size() > 0) {
+
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+  if (from.query().size() > 0) {
+
+    query_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.query_);
+  }
+}
+
+void QueryStateRequest::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.QueryStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void QueryStateRequest::CopyFrom(const QueryStateRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.QueryStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool QueryStateRequest::IsInitialized() const {
+  return true;
+}
+
+void QueryStateRequest::Swap(QueryStateRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void QueryStateRequest::InternalSwap(QueryStateRequest* other) {
+  using std::swap;
+  metadata_.Swap(&other->metadata_);
+  store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  query_.Swap(&other->query_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata QueryStateRequest::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void QueryStateItem::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int QueryStateItem::kKeyFieldNumber;
+const int QueryStateItem::kDataFieldNumber;
+const int QueryStateItem::kEtagFieldNumber;
+const int QueryStateItem::kErrorFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+QueryStateItem::QueryStateItem()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateItem.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.QueryStateItem)
+}
+QueryStateItem::QueryStateItem(const QueryStateItem& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.key().size() > 0) {
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.data().size() > 0) {
+    data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
+  }
+  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.etag().size() > 0) {
+    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  }
+  error_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.error().size() > 0) {
+    error_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.error_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.QueryStateItem)
+}
+
+void QueryStateItem::SharedCtor() {
+  key_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  etag_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+QueryStateItem::~QueryStateItem() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.QueryStateItem)
+  SharedDtor();
+}
+
+void QueryStateItem::SharedDtor() {
+  key_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  data_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  etag_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void QueryStateItem::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* QueryStateItem::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const QueryStateItem& QueryStateItem::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateItem.base);
+  return *internal_default_instance();
+}
+
+
+void QueryStateItem::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.QueryStateItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  error_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool QueryStateItem::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.QueryStateItem)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string key = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_key()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->key().data(), static_cast<int>(this->key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateItem.key"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // bytes data = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_data()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string etag = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_etag()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->etag().data(), static_cast<int>(this->etag().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateItem.etag"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string error = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_error()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->error().data(), static_cast<int>(this->error().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateItem.error"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.QueryStateItem)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.QueryStateItem)
+  return false;
+#undef DO_
+}
+
+void QueryStateItem::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.QueryStateItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.key");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->key(), output);
+  }
+
+  // bytes data = 2;
+  if (this->data().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      2, this->data(), output);
+  }
+
+  // string etag = 3;
+  if (this->etag().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->etag().data(), static_cast<int>(this->etag().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.etag");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      3, this->etag(), output);
+  }
+
+  // string error = 4;
+  if (this->error().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->error().data(), static_cast<int>(this->error().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.error");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      4, this->error(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.QueryStateItem)
+}
+
+::google::protobuf::uint8* QueryStateItem::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.QueryStateItem)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string key = 1;
+  if (this->key().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->key().data(), static_cast<int>(this->key().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.key");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->key(), target);
+  }
+
+  // bytes data = 2;
+  if (this->data().size() > 0) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        2, this->data(), target);
+  }
+
+  // string etag = 3;
+  if (this->etag().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->etag().data(), static_cast<int>(this->etag().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.etag");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        3, this->etag(), target);
+  }
+
+  // string error = 4;
+  if (this->error().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->error().data(), static_cast<int>(this->error().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateItem.error");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        4, this->error(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.QueryStateItem)
+  return target;
+}
+
+size_t QueryStateItem::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.QueryStateItem)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string key = 1;
+  if (this->key().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->key());
+  }
+
+  // bytes data = 2;
+  if (this->data().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::BytesSize(
+        this->data());
+  }
+
+  // string etag = 3;
+  if (this->etag().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->etag());
+  }
+
+  // string error = 4;
+  if (this->error().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->error());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void QueryStateItem::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.QueryStateItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  const QueryStateItem* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const QueryStateItem>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.QueryStateItem)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.QueryStateItem)
+    MergeFrom(*source);
+  }
+}
+
+void QueryStateItem::MergeFrom(const QueryStateItem& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.QueryStateItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.key().size() > 0) {
+
+    key_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.key_);
+  }
+  if (from.data().size() > 0) {
+
+    data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
+  }
+  if (from.etag().size() > 0) {
+
+    etag_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.etag_);
+  }
+  if (from.error().size() > 0) {
+
+    error_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.error_);
+  }
+}
+
+void QueryStateItem::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.QueryStateItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void QueryStateItem::CopyFrom(const QueryStateItem& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.QueryStateItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool QueryStateItem::IsInitialized() const {
+  return true;
+}
+
+void QueryStateItem::Swap(QueryStateItem* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void QueryStateItem::InternalSwap(QueryStateItem* other) {
+  using std::swap;
+  key_.Swap(&other->key_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  data_.Swap(&other->data_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  etag_.Swap(&other->etag_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  error_.Swap(&other->error_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata QueryStateItem::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+QueryStateResponse_MetadataEntry_DoNotUse::QueryStateResponse_MetadataEntry_DoNotUse() {}
+QueryStateResponse_MetadataEntry_DoNotUse::QueryStateResponse_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void QueryStateResponse_MetadataEntry_DoNotUse::MergeFrom(const QueryStateResponse_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata QueryStateResponse_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[17];
+}
+void QueryStateResponse_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void QueryStateResponse::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int QueryStateResponse::kResultsFieldNumber;
+const int QueryStateResponse::kTokenFieldNumber;
+const int QueryStateResponse::kMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+QueryStateResponse::QueryStateResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateResponse.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.QueryStateResponse)
+}
+QueryStateResponse::QueryStateResponse(const QueryStateResponse& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      results_(from.results_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
+  token_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.token().size() > 0) {
+    token_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.token_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.QueryStateResponse)
+}
+
+void QueryStateResponse::SharedCtor() {
+  token_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+QueryStateResponse::~QueryStateResponse() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.QueryStateResponse)
+  SharedDtor();
+}
+
+void QueryStateResponse::SharedDtor() {
+  token_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void QueryStateResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* QueryStateResponse::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const QueryStateResponse& QueryStateResponse::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_QueryStateResponse.base);
+  return *internal_default_instance();
+}
+
+
+void QueryStateResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.QueryStateResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  results_.Clear();
+  metadata_.Clear();
+  token_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool QueryStateResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.QueryStateResponse)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_results()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string token = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_token()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->token().data(), static_cast<int>(this->token().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateResponse.token"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> metadata = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          QueryStateResponse_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              QueryStateResponse_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.QueryStateResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.QueryStateResponse)
+  return false;
+#undef DO_
+}
+
+void QueryStateResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.QueryStateResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->results_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1,
+      this->results(static_cast<int>(i)),
+      output);
+  }
+
+  // string token = 2;
+  if (this->token().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->token().data(), static_cast<int>(this->token().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateResponse.token");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->token(), output);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<QueryStateResponse_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<QueryStateResponse_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.QueryStateResponse)
+}
+
+::google::protobuf::uint8* QueryStateResponse::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.QueryStateResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->results_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, this->results(static_cast<int>(i)), deterministic, target);
+  }
+
+  // string token = 2;
+  if (this->token().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->token().data(), static_cast<int>(this->token().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.QueryStateResponse.token");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->token(), target);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.QueryStateResponse.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<QueryStateResponse_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<QueryStateResponse_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.QueryStateResponse)
+  return target;
+}
+
+size_t QueryStateResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.QueryStateResponse)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+  {
+    unsigned int count = static_cast<unsigned int>(this->results_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->results(static_cast<int>(i)));
+    }
+  }
+
+  // map<string, string> metadata = 3;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<QueryStateResponse_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string token = 2;
+  if (this->token().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->token());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void QueryStateResponse::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.QueryStateResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const QueryStateResponse* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const QueryStateResponse>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.QueryStateResponse)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.QueryStateResponse)
+    MergeFrom(*source);
+  }
+}
+
+void QueryStateResponse::MergeFrom(const QueryStateResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.QueryStateResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  results_.MergeFrom(from.results_);
+  metadata_.MergeFrom(from.metadata_);
+  if (from.token().size() > 0) {
+
+    token_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.token_);
+  }
+}
+
+void QueryStateResponse::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.QueryStateResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void QueryStateResponse::CopyFrom(const QueryStateResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.QueryStateResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool QueryStateResponse::IsInitialized() const {
+  return true;
+}
+
+void QueryStateResponse::Swap(QueryStateResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void QueryStateResponse::InternalSwap(QueryStateResponse* other) {
+  using std::swap;
+  CastToBase(&results_)->InternalSwap(CastToBase(&other->results_));
+  metadata_.Swap(&other->metadata_);
+  token_.Swap(&other->token_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata QueryStateResponse::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
 PublishEventRequest_MetadataEntry_DoNotUse::PublishEventRequest_MetadataEntry_DoNotUse() {}
 PublishEventRequest_MetadataEntry_DoNotUse::PublishEventRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
 void PublishEventRequest_MetadataEntry_DoNotUse::MergeFrom(const PublishEventRequest_MetadataEntry_DoNotUse& other) {
@@ -5519,7 +7234,7 @@ void PublishEventRequest_MetadataEntry_DoNotUse::MergeFrom(const PublishEventReq
 }
 ::google::protobuf::Metadata PublishEventRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[14];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[19];
 }
 void PublishEventRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6096,7 +7811,7 @@ void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(const InvokeBindingR
 }
 ::google::protobuf::Metadata InvokeBindingRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[16];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[21];
 }
 void InvokeBindingRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -6615,7 +8330,7 @@ void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(const InvokeBinding
 }
 ::google::protobuf::Metadata InvokeBindingResponse_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[18];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[23];
 }
 void InvokeBindingResponse_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7018,7 +8733,7 @@ void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(const GetSecretRequest_M
 }
 ::google::protobuf::Metadata GetSecretRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[20];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[25];
 }
 void GetSecretRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7491,7 +9206,7 @@ void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetSecretResponse_Dat
 }
 ::google::protobuf::Metadata GetSecretResponse_DataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[22];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[27];
 }
 void GetSecretResponse_DataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -7848,7 +9563,7 @@ void GetBulkSecretRequest_MetadataEntry_DoNotUse::MergeFrom(const GetBulkSecretR
 }
 ::google::protobuf::Metadata GetBulkSecretRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[24];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[29];
 }
 void GetBulkSecretRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -8263,7 +9978,7 @@ void SecretResponse_SecretsEntry_DoNotUse::MergeFrom(const SecretResponse_Secret
 }
 ::google::protobuf::Metadata SecretResponse_SecretsEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[26];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[31];
 }
 void SecretResponse_SecretsEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -8620,7 +10335,7 @@ void GetBulkSecretResponse_DataEntry_DoNotUse::MergeFrom(const GetBulkSecretResp
 }
 ::google::protobuf::Metadata GetBulkSecretResponse_DataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[28];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[33];
 }
 void GetBulkSecretResponse_DataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -9263,7 +10978,7 @@ void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(const Exec
 }
 ::google::protobuf::Metadata ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[31];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[36];
 }
 void ExecuteStateTransactionRequest_MetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -9726,6 +11441,7 @@ const int RegisterActorTimerRequest::kDueTimeFieldNumber;
 const int RegisterActorTimerRequest::kPeriodFieldNumber;
 const int RegisterActorTimerRequest::kCallbackFieldNumber;
 const int RegisterActorTimerRequest::kDataFieldNumber;
+const int RegisterActorTimerRequest::kTtlFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 RegisterActorTimerRequest::RegisterActorTimerRequest()
@@ -9767,6 +11483,10 @@ RegisterActorTimerRequest::RegisterActorTimerRequest(const RegisterActorTimerReq
   if (from.data().size() > 0) {
     data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
   }
+  ttl_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.ttl().size() > 0) {
+    ttl_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.ttl_);
+  }
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.RegisterActorTimerRequest)
 }
 
@@ -9778,6 +11498,7 @@ void RegisterActorTimerRequest::SharedCtor() {
   period_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   callback_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 RegisterActorTimerRequest::~RegisterActorTimerRequest() {
@@ -9793,6 +11514,7 @@ void RegisterActorTimerRequest::SharedDtor() {
   period_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   callback_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void RegisterActorTimerRequest::SetCachedSize(int size) const {
@@ -9822,6 +11544,7 @@ void RegisterActorTimerRequest::Clear() {
   period_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   callback_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -9943,6 +11666,22 @@ bool RegisterActorTimerRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // string ttl = 8;
+      case 8: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_ttl()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->ttl().data(), static_cast<int>(this->ttl().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -10035,6 +11774,16 @@ void RegisterActorTimerRequest::SerializeWithCachedSizes(
       7, this->data(), output);
   }
 
+  // string ttl = 8;
+  if (this->ttl().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->ttl().data(), static_cast<int>(this->ttl().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      8, this->ttl(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -10122,6 +11871,17 @@ void RegisterActorTimerRequest::SerializeWithCachedSizes(
         7, this->data(), target);
   }
 
+  // string ttl = 8;
+  if (this->ttl().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->ttl().data(), static_cast<int>(this->ttl().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        8, this->ttl(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -10188,6 +11948,13 @@ size_t RegisterActorTimerRequest::ByteSizeLong() const {
         this->data());
   }
 
+  // string ttl = 8;
+  if (this->ttl().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->ttl());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -10243,6 +12010,10 @@ void RegisterActorTimerRequest::MergeFrom(const RegisterActorTimerRequest& from)
 
     data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
   }
+  if (from.ttl().size() > 0) {
+
+    ttl_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.ttl_);
+  }
 }
 
 void RegisterActorTimerRequest::CopyFrom(const ::google::protobuf::Message& from) {
@@ -10282,6 +12053,8 @@ void RegisterActorTimerRequest::InternalSwap(RegisterActorTimerRequest* other) {
   callback_.Swap(&other->callback_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   data_.Swap(&other->data_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  ttl_.Swap(&other->ttl_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
@@ -10661,6 +12434,7 @@ const int RegisterActorReminderRequest::kNameFieldNumber;
 const int RegisterActorReminderRequest::kDueTimeFieldNumber;
 const int RegisterActorReminderRequest::kPeriodFieldNumber;
 const int RegisterActorReminderRequest::kDataFieldNumber;
+const int RegisterActorReminderRequest::kTtlFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 RegisterActorReminderRequest::RegisterActorReminderRequest()
@@ -10698,6 +12472,10 @@ RegisterActorReminderRequest::RegisterActorReminderRequest(const RegisterActorRe
   if (from.data().size() > 0) {
     data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
   }
+  ttl_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.ttl().size() > 0) {
+    ttl_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.ttl_);
+  }
   // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.RegisterActorReminderRequest)
 }
 
@@ -10708,6 +12486,7 @@ void RegisterActorReminderRequest::SharedCtor() {
   due_time_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   period_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 RegisterActorReminderRequest::~RegisterActorReminderRequest() {
@@ -10722,6 +12501,7 @@ void RegisterActorReminderRequest::SharedDtor() {
   due_time_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   period_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void RegisterActorReminderRequest::SetCachedSize(int size) const {
@@ -10750,6 +12530,7 @@ void RegisterActorReminderRequest::Clear() {
   due_time_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   period_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ttl_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -10855,6 +12636,22 @@ bool RegisterActorReminderRequest::MergePartialFromCodedStream(
         break;
       }
 
+      // string ttl = 7;
+      case 7: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_ttl()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->ttl().data(), static_cast<int>(this->ttl().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -10937,6 +12734,16 @@ void RegisterActorReminderRequest::SerializeWithCachedSizes(
       6, this->data(), output);
   }
 
+  // string ttl = 7;
+  if (this->ttl().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->ttl().data(), static_cast<int>(this->ttl().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      7, this->ttl(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -11013,6 +12820,17 @@ void RegisterActorReminderRequest::SerializeWithCachedSizes(
         6, this->data(), target);
   }
 
+  // string ttl = 7;
+  if (this->ttl().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->ttl().data(), static_cast<int>(this->ttl().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        7, this->ttl(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -11072,6 +12890,13 @@ size_t RegisterActorReminderRequest::ByteSizeLong() const {
         this->data());
   }
 
+  // string ttl = 7;
+  if (this->ttl().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->ttl());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -11123,6 +12948,10 @@ void RegisterActorReminderRequest::MergeFrom(const RegisterActorReminderRequest&
 
     data_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.data_);
   }
+  if (from.ttl().size() > 0) {
+
+    ttl_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.ttl_);
+  }
 }
 
 void RegisterActorReminderRequest::CopyFrom(const ::google::protobuf::Message& from) {
@@ -11160,6 +12989,8 @@ void RegisterActorReminderRequest::InternalSwap(RegisterActorReminderRequest* ot
   period_.Swap(&other->period_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   data_.Swap(&other->data_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  ttl_.Swap(&other->ttl_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
@@ -13460,7 +15291,7 @@ void GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::MergeFrom(const GetMeta
 }
 ::google::protobuf::Metadata GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::GetMetadata() const {
   ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[43];
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[48];
 }
 void GetMetadataResponse_ExtendedMetadataEntry_DoNotUse::MergeFrom(
     const ::google::protobuf::Message& other) {
@@ -14895,6 +16726,1400 @@ void SetMetadataRequest::InternalSwap(SetMetadataRequest* other) {
 }
 
 
+// ===================================================================
+
+GetConfigurationRequest_MetadataEntry_DoNotUse::GetConfigurationRequest_MetadataEntry_DoNotUse() {}
+GetConfigurationRequest_MetadataEntry_DoNotUse::GetConfigurationRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GetConfigurationRequest_MetadataEntry_DoNotUse::MergeFrom(const GetConfigurationRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GetConfigurationRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[53];
+}
+void GetConfigurationRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void GetConfigurationRequest::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GetConfigurationRequest::kStoreNameFieldNumber;
+const int GetConfigurationRequest::kKeysFieldNumber;
+const int GetConfigurationRequest::kMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GetConfigurationRequest::GetConfigurationRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetConfigurationRequest.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.GetConfigurationRequest)
+}
+GetConfigurationRequest::GetConfigurationRequest(const GetConfigurationRequest& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      keys_(from.keys_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.store_name().size() > 0) {
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.GetConfigurationRequest)
+}
+
+void GetConfigurationRequest::SharedCtor() {
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+GetConfigurationRequest::~GetConfigurationRequest() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.GetConfigurationRequest)
+  SharedDtor();
+}
+
+void GetConfigurationRequest::SharedDtor() {
+  store_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void GetConfigurationRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* GetConfigurationRequest::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GetConfigurationRequest& GetConfigurationRequest::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetConfigurationRequest.base);
+  return *internal_default_instance();
+}
+
+
+void GetConfigurationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  keys_.Clear();
+  metadata_.Clear();
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool GetConfigurationRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string store_name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_store_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->store_name().data(), static_cast<int>(this->store_name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetConfigurationRequest.store_name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated string keys = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_keys()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->keys(this->keys_size() - 1).data(),
+            static_cast<int>(this->keys(this->keys_size() - 1).length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetConfigurationRequest.keys"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> metadata = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          GetConfigurationRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GetConfigurationRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.GetConfigurationRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.GetConfigurationRequest)
+  return false;
+#undef DO_
+}
+
+void GetConfigurationRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetConfigurationRequest.store_name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->store_name(), output);
+  }
+
+  // repeated string keys = 2;
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->keys(i).data(), static_cast<int>(this->keys(i).length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetConfigurationRequest.keys");
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      2, this->keys(i), output);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.GetConfigurationRequest)
+}
+
+::google::protobuf::uint8* GetConfigurationRequest::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetConfigurationRequest.store_name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->store_name(), target);
+  }
+
+  // repeated string keys = 2;
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->keys(i).data(), static_cast<int>(this->keys(i).length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.GetConfigurationRequest.keys");
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(2, this->keys(i), target);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.GetConfigurationRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<GetConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<GetConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.GetConfigurationRequest)
+  return target;
+}
+
+size_t GetConfigurationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated string keys = 2;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->keys_size());
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->keys(i));
+  }
+
+  // map<string, string> metadata = 3;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<GetConfigurationRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->store_name());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GetConfigurationRequest::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GetConfigurationRequest* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GetConfigurationRequest>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.GetConfigurationRequest)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.GetConfigurationRequest)
+    MergeFrom(*source);
+  }
+}
+
+void GetConfigurationRequest::MergeFrom(const GetConfigurationRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  keys_.MergeFrom(from.keys_);
+  metadata_.MergeFrom(from.metadata_);
+  if (from.store_name().size() > 0) {
+
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+}
+
+void GetConfigurationRequest::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetConfigurationRequest::CopyFrom(const GetConfigurationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.GetConfigurationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetConfigurationRequest::IsInitialized() const {
+  return true;
+}
+
+void GetConfigurationRequest::Swap(GetConfigurationRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GetConfigurationRequest::InternalSwap(GetConfigurationRequest* other) {
+  using std::swap;
+  keys_.InternalSwap(CastToBase(&other->keys_));
+  metadata_.Swap(&other->metadata_);
+  store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata GetConfigurationRequest::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GetConfigurationResponse::InitAsDefaultInstance() {
+}
+void GetConfigurationResponse::clear_items() {
+  items_.Clear();
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GetConfigurationResponse::kItemsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GetConfigurationResponse::GetConfigurationResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetConfigurationResponse.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.GetConfigurationResponse)
+}
+GetConfigurationResponse::GetConfigurationResponse(const GetConfigurationResponse& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      items_(from.items_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.GetConfigurationResponse)
+}
+
+void GetConfigurationResponse::SharedCtor() {
+}
+
+GetConfigurationResponse::~GetConfigurationResponse() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.GetConfigurationResponse)
+  SharedDtor();
+}
+
+void GetConfigurationResponse::SharedDtor() {
+}
+
+void GetConfigurationResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* GetConfigurationResponse::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GetConfigurationResponse& GetConfigurationResponse::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_GetConfigurationResponse.base);
+  return *internal_default_instance();
+}
+
+
+void GetConfigurationResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  items_.Clear();
+  _internal_metadata_.Clear();
+}
+
+bool GetConfigurationResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_items()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.GetConfigurationResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.GetConfigurationResponse)
+  return false;
+#undef DO_
+}
+
+void GetConfigurationResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->items_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1,
+      this->items(static_cast<int>(i)),
+      output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.GetConfigurationResponse)
+}
+
+::google::protobuf::uint8* GetConfigurationResponse::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->items_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, this->items(static_cast<int>(i)), deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.GetConfigurationResponse)
+  return target;
+}
+
+size_t GetConfigurationResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  {
+    unsigned int count = static_cast<unsigned int>(this->items_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->items(static_cast<int>(i)));
+    }
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void GetConfigurationResponse::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GetConfigurationResponse* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GetConfigurationResponse>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.GetConfigurationResponse)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.GetConfigurationResponse)
+    MergeFrom(*source);
+  }
+}
+
+void GetConfigurationResponse::MergeFrom(const GetConfigurationResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  items_.MergeFrom(from.items_);
+}
+
+void GetConfigurationResponse::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetConfigurationResponse::CopyFrom(const GetConfigurationResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.GetConfigurationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetConfigurationResponse::IsInitialized() const {
+  return true;
+}
+
+void GetConfigurationResponse::Swap(GetConfigurationResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GetConfigurationResponse::InternalSwap(GetConfigurationResponse* other) {
+  using std::swap;
+  CastToBase(&items_)->InternalSwap(CastToBase(&other->items_));
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata GetConfigurationResponse::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+SubscribeConfigurationRequest_MetadataEntry_DoNotUse::SubscribeConfigurationRequest_MetadataEntry_DoNotUse() {}
+SubscribeConfigurationRequest_MetadataEntry_DoNotUse::SubscribeConfigurationRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void SubscribeConfigurationRequest_MetadataEntry_DoNotUse::MergeFrom(const SubscribeConfigurationRequest_MetadataEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata SubscribeConfigurationRequest_MetadataEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[56];
+}
+void SubscribeConfigurationRequest_MetadataEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void SubscribeConfigurationRequest::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int SubscribeConfigurationRequest::kStoreNameFieldNumber;
+const int SubscribeConfigurationRequest::kKeysFieldNumber;
+const int SubscribeConfigurationRequest::kMetadataFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+SubscribeConfigurationRequest::SubscribeConfigurationRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SubscribeConfigurationRequest.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+}
+SubscribeConfigurationRequest::SubscribeConfigurationRequest(const SubscribeConfigurationRequest& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      keys_(from.keys_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  metadata_.MergeFrom(from.metadata_);
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.store_name().size() > 0) {
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+}
+
+void SubscribeConfigurationRequest::SharedCtor() {
+  store_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+SubscribeConfigurationRequest::~SubscribeConfigurationRequest() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  SharedDtor();
+}
+
+void SubscribeConfigurationRequest::SharedDtor() {
+  store_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void SubscribeConfigurationRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* SubscribeConfigurationRequest::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const SubscribeConfigurationRequest& SubscribeConfigurationRequest::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SubscribeConfigurationRequest.base);
+  return *internal_default_instance();
+}
+
+
+void SubscribeConfigurationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  keys_.Clear();
+  metadata_.Clear();
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool SubscribeConfigurationRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string store_name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_store_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->store_name().data(), static_cast<int>(this->store_name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated string keys = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_keys()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->keys(this->keys_size() - 1).data(),
+            static_cast<int>(this->keys(this->keys_size() - 1).length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> metadata = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          SubscribeConfigurationRequest_MetadataEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              SubscribeConfigurationRequest_MetadataEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&metadata_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  return false;
+#undef DO_
+}
+
+void SubscribeConfigurationRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->store_name(), output);
+  }
+
+  // repeated string keys = 2;
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->keys(i).data(), static_cast<int>(this->keys(i).length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys");
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      2, this->keys(i), output);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<SubscribeConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<SubscribeConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            3, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+}
+
+::google::protobuf::uint8* SubscribeConfigurationRequest::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->store_name().data(), static_cast<int>(this->store_name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->store_name(), target);
+  }
+
+  // repeated string keys = 2;
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->keys(i).data(), static_cast<int>(this->keys(i).length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys");
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(2, this->keys(i), target);
+  }
+
+  // map<string, string> metadata = 3;
+  if (!this->metadata().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "dapr.proto.runtime.v1.SubscribeConfigurationRequest.MetadataEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->metadata().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->metadata().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::std::unique_ptr<SubscribeConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(metadata_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::std::unique_ptr<SubscribeConfigurationRequest_MetadataEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->metadata().begin();
+          it != this->metadata().end(); ++it) {
+        entry.reset(metadata_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       3, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  return target;
+}
+
+size_t SubscribeConfigurationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated string keys = 2;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->keys_size());
+  for (int i = 0, n = this->keys_size(); i < n; i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->keys(i));
+  }
+
+  // map<string, string> metadata = 3;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->metadata_size());
+  {
+    ::std::unique_ptr<SubscribeConfigurationRequest_MetadataEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->metadata().begin();
+        it != this->metadata().end(); ++it) {
+      entry.reset(metadata_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string store_name = 1;
+  if (this->store_name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->store_name());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SubscribeConfigurationRequest::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SubscribeConfigurationRequest* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const SubscribeConfigurationRequest>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+    MergeFrom(*source);
+  }
+}
+
+void SubscribeConfigurationRequest::MergeFrom(const SubscribeConfigurationRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  keys_.MergeFrom(from.keys_);
+  metadata_.MergeFrom(from.metadata_);
+  if (from.store_name().size() > 0) {
+
+    store_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.store_name_);
+  }
+}
+
+void SubscribeConfigurationRequest::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SubscribeConfigurationRequest::CopyFrom(const SubscribeConfigurationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeConfigurationRequest::IsInitialized() const {
+  return true;
+}
+
+void SubscribeConfigurationRequest::Swap(SubscribeConfigurationRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SubscribeConfigurationRequest::InternalSwap(SubscribeConfigurationRequest* other) {
+  using std::swap;
+  keys_.InternalSwap(CastToBase(&other->keys_));
+  metadata_.Swap(&other->metadata_);
+  store_name_.Swap(&other->store_name_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata SubscribeConfigurationRequest::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void SubscribeConfigurationResponse::InitAsDefaultInstance() {
+}
+void SubscribeConfigurationResponse::clear_items() {
+  items_.Clear();
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int SubscribeConfigurationResponse::kItemsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+SubscribeConfigurationResponse::SubscribeConfigurationResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SubscribeConfigurationResponse.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+}
+SubscribeConfigurationResponse::SubscribeConfigurationResponse(const SubscribeConfigurationResponse& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      items_(from.items_) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+}
+
+void SubscribeConfigurationResponse::SharedCtor() {
+}
+
+SubscribeConfigurationResponse::~SubscribeConfigurationResponse() {
+  // @@protoc_insertion_point(destructor:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  SharedDtor();
+}
+
+void SubscribeConfigurationResponse::SharedDtor() {
+}
+
+void SubscribeConfigurationResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* SubscribeConfigurationResponse::descriptor() {
+  ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const SubscribeConfigurationResponse& SubscribeConfigurationResponse::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::scc_info_SubscribeConfigurationResponse.base);
+  return *internal_default_instance();
+}
+
+
+void SubscribeConfigurationResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  items_.Clear();
+  _internal_metadata_.Clear();
+}
+
+bool SubscribeConfigurationResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+                input, add_items()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  return false;
+#undef DO_
+}
+
+void SubscribeConfigurationResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->items_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1,
+      this->items(static_cast<int>(i)),
+      output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+}
+
+::google::protobuf::uint8* SubscribeConfigurationResponse::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->items_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, this->items(static_cast<int>(i)), deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  return target;
+}
+
+size_t SubscribeConfigurationResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  {
+    unsigned int count = static_cast<unsigned int>(this->items_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->items(static_cast<int>(i)));
+    }
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SubscribeConfigurationResponse::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SubscribeConfigurationResponse* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const SubscribeConfigurationResponse>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+    MergeFrom(*source);
+  }
+}
+
+void SubscribeConfigurationResponse::MergeFrom(const SubscribeConfigurationResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  items_.MergeFrom(from.items_);
+}
+
+void SubscribeConfigurationResponse::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SubscribeConfigurationResponse::CopyFrom(const SubscribeConfigurationResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SubscribeConfigurationResponse::IsInitialized() const {
+  return true;
+}
+
+void SubscribeConfigurationResponse::Swap(SubscribeConfigurationResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SubscribeConfigurationResponse::InternalSwap(SubscribeConfigurationResponse* other) {
+  using std::swap;
+  CastToBase(&items_)->InternalSwap(CastToBase(&other->items_));
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata SubscribeConfigurationResponse::GetMetadata() const {
+  protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace v1
 }  // namespace runtime
@@ -14943,6 +18168,21 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::Delete
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SaveStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SaveStateRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::SaveStateRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::QueryStateRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::QueryStateRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::QueryStateRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::QueryStateItem* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::QueryStateItem >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::QueryStateItem >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::QueryStateResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::QueryStateResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::QueryStateResponse >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse >(arena);
@@ -15045,6 +18285,24 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::Regist
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SetMetadataRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SetMetadataRequest >(Arena* arena) {
   return Arena::CreateInternal< ::dapr::proto::runtime::v1::SetMetadataRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetConfigurationRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetConfigurationRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetConfigurationRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::GetConfigurationResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::GetConfigurationResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::GetConfigurationResponse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SubscribeConfigurationRequest >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::dapr::proto::runtime::v1::SubscribeConfigurationResponse* Arena::CreateMaybeMessage< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse >(Arena* arena) {
+  return Arena::CreateInternal< ::dapr::proto::runtime::v1::SubscribeConfigurationResponse >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/dapr/proto/runtime/v1/dapr.pb.h
+++ b/src/dapr/proto/runtime/v1/dapr.pb.h
@@ -44,7 +44,7 @@ namespace protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[48];
+  static const ::google::protobuf::internal::ParseTable schema[59];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -109,6 +109,15 @@ extern GetBulkStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _GetBulkSta
 class GetBulkStateResponse;
 class GetBulkStateResponseDefaultTypeInternal;
 extern GetBulkStateResponseDefaultTypeInternal _GetBulkStateResponse_default_instance_;
+class GetConfigurationRequest;
+class GetConfigurationRequestDefaultTypeInternal;
+extern GetConfigurationRequestDefaultTypeInternal _GetConfigurationRequest_default_instance_;
+class GetConfigurationRequest_MetadataEntry_DoNotUse;
+class GetConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern GetConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal _GetConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+class GetConfigurationResponse;
+class GetConfigurationResponseDefaultTypeInternal;
+extern GetConfigurationResponseDefaultTypeInternal _GetConfigurationResponse_default_instance_;
 class GetMetadataResponse;
 class GetMetadataResponseDefaultTypeInternal;
 extern GetMetadataResponseDefaultTypeInternal _GetMetadataResponse_default_instance_;
@@ -166,6 +175,21 @@ extern PublishEventRequestDefaultTypeInternal _PublishEventRequest_default_insta
 class PublishEventRequest_MetadataEntry_DoNotUse;
 class PublishEventRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
 extern PublishEventRequest_MetadataEntry_DoNotUseDefaultTypeInternal _PublishEventRequest_MetadataEntry_DoNotUse_default_instance_;
+class QueryStateItem;
+class QueryStateItemDefaultTypeInternal;
+extern QueryStateItemDefaultTypeInternal _QueryStateItem_default_instance_;
+class QueryStateRequest;
+class QueryStateRequestDefaultTypeInternal;
+extern QueryStateRequestDefaultTypeInternal _QueryStateRequest_default_instance_;
+class QueryStateRequest_MetadataEntry_DoNotUse;
+class QueryStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern QueryStateRequest_MetadataEntry_DoNotUseDefaultTypeInternal _QueryStateRequest_MetadataEntry_DoNotUse_default_instance_;
+class QueryStateResponse;
+class QueryStateResponseDefaultTypeInternal;
+extern QueryStateResponseDefaultTypeInternal _QueryStateResponse_default_instance_;
+class QueryStateResponse_MetadataEntry_DoNotUse;
+class QueryStateResponse_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern QueryStateResponse_MetadataEntry_DoNotUseDefaultTypeInternal _QueryStateResponse_MetadataEntry_DoNotUse_default_instance_;
 class RegisterActorReminderRequest;
 class RegisterActorReminderRequestDefaultTypeInternal;
 extern RegisterActorReminderRequestDefaultTypeInternal _RegisterActorReminderRequest_default_instance_;
@@ -187,6 +211,15 @@ extern SecretResponse_SecretsEntry_DoNotUseDefaultTypeInternal _SecretResponse_S
 class SetMetadataRequest;
 class SetMetadataRequestDefaultTypeInternal;
 extern SetMetadataRequestDefaultTypeInternal _SetMetadataRequest_default_instance_;
+class SubscribeConfigurationRequest;
+class SubscribeConfigurationRequestDefaultTypeInternal;
+extern SubscribeConfigurationRequestDefaultTypeInternal _SubscribeConfigurationRequest_default_instance_;
+class SubscribeConfigurationRequest_MetadataEntry_DoNotUse;
+class SubscribeConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal;
+extern SubscribeConfigurationRequest_MetadataEntry_DoNotUseDefaultTypeInternal _SubscribeConfigurationRequest_MetadataEntry_DoNotUse_default_instance_;
+class SubscribeConfigurationResponse;
+class SubscribeConfigurationResponseDefaultTypeInternal;
+extern SubscribeConfigurationResponseDefaultTypeInternal _SubscribeConfigurationResponse_default_instance_;
 class TransactionalActorStateOperation;
 class TransactionalActorStateOperationDefaultTypeInternal;
 extern TransactionalActorStateOperationDefaultTypeInternal _TransactionalActorStateOperation_default_instance_;
@@ -223,6 +256,9 @@ template<> ::dapr::proto::runtime::v1::GetBulkSecretResponse_DataEntry_DoNotUse*
 template<> ::dapr::proto::runtime::v1::GetBulkStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateRequest_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetBulkStateResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetBulkStateResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetConfigurationRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetConfigurationRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetConfigurationRequest_MetadataEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::GetConfigurationResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetConfigurationResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetMetadataResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetMetadataResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetMetadataResponse_ExtendedMetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::GetSecretRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::GetSecretRequest>(Arena*);
@@ -242,6 +278,11 @@ template<> ::dapr::proto::runtime::v1::InvokeBindingResponse_MetadataEntry_DoNot
 template<> ::dapr::proto::runtime::v1::InvokeServiceRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::InvokeServiceRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::PublishEventRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::PublishEventRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::PublishEventRequest_MetadataEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::QueryStateItem* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::QueryStateItem>(Arena*);
+template<> ::dapr::proto::runtime::v1::QueryStateRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::QueryStateRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::QueryStateRequest_MetadataEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::QueryStateResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::QueryStateResponse>(Arena*);
+template<> ::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::QueryStateResponse_MetadataEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::RegisterActorReminderRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisterActorReminderRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::RegisterActorTimerRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisterActorTimerRequest>(Arena*);
 template<> ::dapr::proto::runtime::v1::RegisteredComponents* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::RegisteredComponents>(Arena*);
@@ -249,6 +290,9 @@ template<> ::dapr::proto::runtime::v1::SaveStateRequest* Arena::CreateMaybeMessa
 template<> ::dapr::proto::runtime::v1::SecretResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SecretResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SecretResponse_SecretsEntry_DoNotUse>(Arena*);
 template<> ::dapr::proto::runtime::v1::SetMetadataRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SetMetadataRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::SubscribeConfigurationRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SubscribeConfigurationRequest>(Arena*);
+template<> ::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SubscribeConfigurationRequest_MetadataEntry_DoNotUse>(Arena*);
+template<> ::dapr::proto::runtime::v1::SubscribeConfigurationResponse* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::SubscribeConfigurationResponse>(Arena*);
 template<> ::dapr::proto::runtime::v1::TransactionalActorStateOperation* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TransactionalActorStateOperation>(Arena*);
 template<> ::dapr::proto::runtime::v1::TransactionalStateOperation* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::TransactionalStateOperation>(Arena*);
 template<> ::dapr::proto::runtime::v1::UnregisterActorReminderRequest* Arena::CreateMaybeMessage<::dapr::proto::runtime::v1::UnregisterActorReminderRequest>(Arena*);
@@ -1636,6 +1680,486 @@ class SaveStateRequest : public ::google::protobuf::Message /* @@protoc_insertio
 };
 // -------------------------------------------------------------------
 
+class QueryStateRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<QueryStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<QueryStateRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  QueryStateRequest_MetadataEntry_DoNotUse();
+  QueryStateRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const QueryStateRequest_MetadataEntry_DoNotUse& other);
+  static const QueryStateRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const QueryStateRequest_MetadataEntry_DoNotUse*>(&_QueryStateRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class QueryStateRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.QueryStateRequest) */ {
+ public:
+  QueryStateRequest();
+  virtual ~QueryStateRequest();
+
+  QueryStateRequest(const QueryStateRequest& from);
+
+  inline QueryStateRequest& operator=(const QueryStateRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  QueryStateRequest(QueryStateRequest&& from) noexcept
+    : QueryStateRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline QueryStateRequest& operator=(QueryStateRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const QueryStateRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const QueryStateRequest* internal_default_instance() {
+    return reinterpret_cast<const QueryStateRequest*>(
+               &_QueryStateRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    15;
+
+  void Swap(QueryStateRequest* other);
+  friend void swap(QueryStateRequest& a, QueryStateRequest& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline QueryStateRequest* New() const final {
+    return CreateMaybeMessage<QueryStateRequest>(NULL);
+  }
+
+  QueryStateRequest* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<QueryStateRequest>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const QueryStateRequest& from);
+  void MergeFrom(const QueryStateRequest& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(QueryStateRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // map<string, string> metadata = 3;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 3;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
+
+  // string store_name = 1;
+  void clear_store_name();
+  static const int kStoreNameFieldNumber = 1;
+  const ::std::string& store_name() const;
+  void set_store_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_store_name(::std::string&& value);
+  #endif
+  void set_store_name(const char* value);
+  void set_store_name(const char* value, size_t size);
+  ::std::string* mutable_store_name();
+  ::std::string* release_store_name();
+  void set_allocated_store_name(::std::string* store_name);
+
+  // string query = 2;
+  void clear_query();
+  static const int kQueryFieldNumber = 2;
+  const ::std::string& query() const;
+  void set_query(const ::std::string& value);
+  #if LANG_CXX11
+  void set_query(::std::string&& value);
+  #endif
+  void set_query(const char* value);
+  void set_query(const char* value, size_t size);
+  ::std::string* mutable_query();
+  ::std::string* release_query();
+  void set_allocated_query(::std::string* query);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.QueryStateRequest)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      QueryStateRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
+  ::google::protobuf::internal::ArenaStringPtr store_name_;
+  ::google::protobuf::internal::ArenaStringPtr query_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class QueryStateItem : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.QueryStateItem) */ {
+ public:
+  QueryStateItem();
+  virtual ~QueryStateItem();
+
+  QueryStateItem(const QueryStateItem& from);
+
+  inline QueryStateItem& operator=(const QueryStateItem& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  QueryStateItem(QueryStateItem&& from) noexcept
+    : QueryStateItem() {
+    *this = ::std::move(from);
+  }
+
+  inline QueryStateItem& operator=(QueryStateItem&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const QueryStateItem& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const QueryStateItem* internal_default_instance() {
+    return reinterpret_cast<const QueryStateItem*>(
+               &_QueryStateItem_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    16;
+
+  void Swap(QueryStateItem* other);
+  friend void swap(QueryStateItem& a, QueryStateItem& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline QueryStateItem* New() const final {
+    return CreateMaybeMessage<QueryStateItem>(NULL);
+  }
+
+  QueryStateItem* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<QueryStateItem>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const QueryStateItem& from);
+  void MergeFrom(const QueryStateItem& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(QueryStateItem* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string key = 1;
+  void clear_key();
+  static const int kKeyFieldNumber = 1;
+  const ::std::string& key() const;
+  void set_key(const ::std::string& value);
+  #if LANG_CXX11
+  void set_key(::std::string&& value);
+  #endif
+  void set_key(const char* value);
+  void set_key(const char* value, size_t size);
+  ::std::string* mutable_key();
+  ::std::string* release_key();
+  void set_allocated_key(::std::string* key);
+
+  // bytes data = 2;
+  void clear_data();
+  static const int kDataFieldNumber = 2;
+  const ::std::string& data() const;
+  void set_data(const ::std::string& value);
+  #if LANG_CXX11
+  void set_data(::std::string&& value);
+  #endif
+  void set_data(const char* value);
+  void set_data(const void* value, size_t size);
+  ::std::string* mutable_data();
+  ::std::string* release_data();
+  void set_allocated_data(::std::string* data);
+
+  // string etag = 3;
+  void clear_etag();
+  static const int kEtagFieldNumber = 3;
+  const ::std::string& etag() const;
+  void set_etag(const ::std::string& value);
+  #if LANG_CXX11
+  void set_etag(::std::string&& value);
+  #endif
+  void set_etag(const char* value);
+  void set_etag(const char* value, size_t size);
+  ::std::string* mutable_etag();
+  ::std::string* release_etag();
+  void set_allocated_etag(::std::string* etag);
+
+  // string error = 4;
+  void clear_error();
+  static const int kErrorFieldNumber = 4;
+  const ::std::string& error() const;
+  void set_error(const ::std::string& value);
+  #if LANG_CXX11
+  void set_error(::std::string&& value);
+  #endif
+  void set_error(const char* value);
+  void set_error(const char* value, size_t size);
+  ::std::string* mutable_error();
+  ::std::string* release_error();
+  void set_allocated_error(::std::string* error);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.QueryStateItem)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr key_;
+  ::google::protobuf::internal::ArenaStringPtr data_;
+  ::google::protobuf::internal::ArenaStringPtr etag_;
+  ::google::protobuf::internal::ArenaStringPtr error_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class QueryStateResponse_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<QueryStateResponse_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<QueryStateResponse_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  QueryStateResponse_MetadataEntry_DoNotUse();
+  QueryStateResponse_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const QueryStateResponse_MetadataEntry_DoNotUse& other);
+  static const QueryStateResponse_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const QueryStateResponse_MetadataEntry_DoNotUse*>(&_QueryStateResponse_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class QueryStateResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.QueryStateResponse) */ {
+ public:
+  QueryStateResponse();
+  virtual ~QueryStateResponse();
+
+  QueryStateResponse(const QueryStateResponse& from);
+
+  inline QueryStateResponse& operator=(const QueryStateResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  QueryStateResponse(QueryStateResponse&& from) noexcept
+    : QueryStateResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline QueryStateResponse& operator=(QueryStateResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const QueryStateResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const QueryStateResponse* internal_default_instance() {
+    return reinterpret_cast<const QueryStateResponse*>(
+               &_QueryStateResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    18;
+
+  void Swap(QueryStateResponse* other);
+  friend void swap(QueryStateResponse& a, QueryStateResponse& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline QueryStateResponse* New() const final {
+    return CreateMaybeMessage<QueryStateResponse>(NULL);
+  }
+
+  QueryStateResponse* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<QueryStateResponse>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const QueryStateResponse& from);
+  void MergeFrom(const QueryStateResponse& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(QueryStateResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+  int results_size() const;
+  void clear_results();
+  static const int kResultsFieldNumber = 1;
+  ::dapr::proto::runtime::v1::QueryStateItem* mutable_results(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::QueryStateItem >*
+      mutable_results();
+  const ::dapr::proto::runtime::v1::QueryStateItem& results(int index) const;
+  ::dapr::proto::runtime::v1::QueryStateItem* add_results();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::QueryStateItem >&
+      results() const;
+
+  // map<string, string> metadata = 3;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 3;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
+
+  // string token = 2;
+  void clear_token();
+  static const int kTokenFieldNumber = 2;
+  const ::std::string& token() const;
+  void set_token(const ::std::string& value);
+  #if LANG_CXX11
+  void set_token(::std::string&& value);
+  #endif
+  void set_token(const char* value);
+  void set_token(const char* value, size_t size);
+  ::std::string* mutable_token();
+  ::std::string* release_token();
+  void set_allocated_token(::std::string* token);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.QueryStateResponse)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::QueryStateItem > results_;
+  ::google::protobuf::internal::MapField<
+      QueryStateResponse_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
+  ::google::protobuf::internal::ArenaStringPtr token_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
 class PublishEventRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<PublishEventRequest_MetadataEntry_DoNotUse, 
     ::std::string, ::std::string,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
@@ -1692,7 +2216,7 @@ class PublishEventRequest : public ::google::protobuf::Message /* @@protoc_inser
                &_PublishEventRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    20;
 
   void Swap(PublishEventRequest* other);
   friend void swap(PublishEventRequest& a, PublishEventRequest& b) {
@@ -1885,7 +2409,7 @@ class InvokeBindingRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_InvokeBindingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    22;
 
   void Swap(InvokeBindingRequest* other);
   friend void swap(InvokeBindingRequest& a, InvokeBindingRequest& b) {
@@ -2063,7 +2587,7 @@ class InvokeBindingResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_InvokeBindingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    24;
 
   void Swap(InvokeBindingResponse* other);
   friend void swap(InvokeBindingResponse& a, InvokeBindingResponse& b) {
@@ -2211,7 +2735,7 @@ class GetSecretRequest : public ::google::protobuf::Message /* @@protoc_insertio
                &_GetSecretRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    26;
 
   void Swap(GetSecretRequest* other);
   friend void swap(GetSecretRequest& a, GetSecretRequest& b) {
@@ -2374,7 +2898,7 @@ class GetSecretResponse : public ::google::protobuf::Message /* @@protoc_inserti
                &_GetSecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    28;
 
   void Swap(GetSecretResponse* other);
   friend void swap(GetSecretResponse& a, GetSecretResponse& b) {
@@ -2507,7 +3031,7 @@ class GetBulkSecretRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_GetBulkSecretRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    30;
 
   void Swap(GetBulkSecretRequest* other);
   friend void swap(GetBulkSecretRequest& a, GetBulkSecretRequest& b) {
@@ -2655,7 +3179,7 @@ class SecretResponse : public ::google::protobuf::Message /* @@protoc_insertion_
                &_SecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    32;
 
   void Swap(SecretResponse* other);
   friend void swap(SecretResponse& a, SecretResponse& b) {
@@ -2788,7 +3312,7 @@ class GetBulkSecretResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_GetBulkSecretResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    34;
 
   void Swap(GetBulkSecretResponse* other);
   friend void swap(GetBulkSecretResponse& a, GetBulkSecretResponse& b) {
@@ -2900,7 +3424,7 @@ class TransactionalStateOperation : public ::google::protobuf::Message /* @@prot
                &_TransactionalStateOperation_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    35;
 
   void Swap(TransactionalStateOperation* other);
   friend void swap(TransactionalStateOperation& a, TransactionalStateOperation& b) {
@@ -3045,7 +3569,7 @@ class ExecuteStateTransactionRequest : public ::google::protobuf::Message /* @@p
                &_ExecuteStateTransactionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    37;
 
   void Swap(ExecuteStateTransactionRequest* other);
   friend void swap(ExecuteStateTransactionRequest& a, ExecuteStateTransactionRequest& b) {
@@ -3185,7 +3709,7 @@ class RegisterActorTimerRequest : public ::google::protobuf::Message /* @@protoc
                &_RegisterActorTimerRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    38;
 
   void Swap(RegisterActorTimerRequest* other);
   friend void swap(RegisterActorTimerRequest& a, RegisterActorTimerRequest& b) {
@@ -3335,6 +3859,20 @@ class RegisterActorTimerRequest : public ::google::protobuf::Message /* @@protoc
   ::std::string* release_data();
   void set_allocated_data(::std::string* data);
 
+  // string ttl = 8;
+  void clear_ttl();
+  static const int kTtlFieldNumber = 8;
+  const ::std::string& ttl() const;
+  void set_ttl(const ::std::string& value);
+  #if LANG_CXX11
+  void set_ttl(::std::string&& value);
+  #endif
+  void set_ttl(const char* value);
+  void set_ttl(const char* value, size_t size);
+  ::std::string* mutable_ttl();
+  ::std::string* release_ttl();
+  void set_allocated_ttl(::std::string* ttl);
+
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.RegisterActorTimerRequest)
  private:
 
@@ -3346,6 +3884,7 @@ class RegisterActorTimerRequest : public ::google::protobuf::Message /* @@protoc
   ::google::protobuf::internal::ArenaStringPtr period_;
   ::google::protobuf::internal::ArenaStringPtr callback_;
   ::google::protobuf::internal::ArenaStringPtr data_;
+  ::google::protobuf::internal::ArenaStringPtr ttl_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -3386,7 +3925,7 @@ class UnregisterActorTimerRequest : public ::google::protobuf::Message /* @@prot
                &_UnregisterActorTimerRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    39;
 
   void Swap(UnregisterActorTimerRequest* other);
   friend void swap(UnregisterActorTimerRequest& a, UnregisterActorTimerRequest& b) {
@@ -3527,7 +4066,7 @@ class RegisterActorReminderRequest : public ::google::protobuf::Message /* @@pro
                &_RegisterActorReminderRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    35;
+    40;
 
   void Swap(RegisterActorReminderRequest* other);
   friend void swap(RegisterActorReminderRequest& a, RegisterActorReminderRequest& b) {
@@ -3663,6 +4202,20 @@ class RegisterActorReminderRequest : public ::google::protobuf::Message /* @@pro
   ::std::string* release_data();
   void set_allocated_data(::std::string* data);
 
+  // string ttl = 7;
+  void clear_ttl();
+  static const int kTtlFieldNumber = 7;
+  const ::std::string& ttl() const;
+  void set_ttl(const ::std::string& value);
+  #if LANG_CXX11
+  void set_ttl(::std::string&& value);
+  #endif
+  void set_ttl(const char* value);
+  void set_ttl(const char* value, size_t size);
+  ::std::string* mutable_ttl();
+  ::std::string* release_ttl();
+  void set_allocated_ttl(::std::string* ttl);
+
   // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.RegisterActorReminderRequest)
  private:
 
@@ -3673,6 +4226,7 @@ class RegisterActorReminderRequest : public ::google::protobuf::Message /* @@pro
   ::google::protobuf::internal::ArenaStringPtr due_time_;
   ::google::protobuf::internal::ArenaStringPtr period_;
   ::google::protobuf::internal::ArenaStringPtr data_;
+  ::google::protobuf::internal::ArenaStringPtr ttl_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -3713,7 +4267,7 @@ class UnregisterActorReminderRequest : public ::google::protobuf::Message /* @@p
                &_UnregisterActorReminderRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    36;
+    41;
 
   void Swap(UnregisterActorReminderRequest* other);
   friend void swap(UnregisterActorReminderRequest& a, UnregisterActorReminderRequest& b) {
@@ -3854,7 +4408,7 @@ class GetActorStateRequest : public ::google::protobuf::Message /* @@protoc_inse
                &_GetActorStateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    37;
+    42;
 
   void Swap(GetActorStateRequest* other);
   friend void swap(GetActorStateRequest& a, GetActorStateRequest& b) {
@@ -3995,7 +4549,7 @@ class GetActorStateResponse : public ::google::protobuf::Message /* @@protoc_ins
                &_GetActorStateResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    38;
+    43;
 
   void Swap(GetActorStateResponse* other);
   friend void swap(GetActorStateResponse& a, GetActorStateResponse& b) {
@@ -4106,7 +4660,7 @@ class ExecuteActorStateTransactionRequest : public ::google::protobuf::Message /
                &_ExecuteActorStateTransactionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    39;
+    44;
 
   void Swap(ExecuteActorStateTransactionRequest* other);
   friend void swap(ExecuteActorStateTransactionRequest& a, ExecuteActorStateTransactionRequest& b) {
@@ -4245,7 +4799,7 @@ class TransactionalActorStateOperation : public ::google::protobuf::Message /* @
                &_TransactionalActorStateOperation_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    40;
+    45;
 
   void Swap(TransactionalActorStateOperation* other);
   friend void swap(TransactionalActorStateOperation& a, TransactionalActorStateOperation& b) {
@@ -4384,7 +4938,7 @@ class InvokeActorRequest : public ::google::protobuf::Message /* @@protoc_insert
                &_InvokeActorRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    41;
+    46;
 
   void Swap(InvokeActorRequest* other);
   friend void swap(InvokeActorRequest& a, InvokeActorRequest& b) {
@@ -4540,7 +5094,7 @@ class InvokeActorResponse : public ::google::protobuf::Message /* @@protoc_inser
                &_InvokeActorResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    42;
+    47;
 
   void Swap(InvokeActorResponse* other);
   friend void swap(InvokeActorResponse& a, InvokeActorResponse& b) {
@@ -4672,7 +5226,7 @@ class GetMetadataResponse : public ::google::protobuf::Message /* @@protoc_inser
                &_GetMetadataResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    44;
+    49;
 
   void Swap(GetMetadataResponse* other);
   friend void swap(GetMetadataResponse& a, GetMetadataResponse& b) {
@@ -4825,7 +5379,7 @@ class ActiveActorsCount : public ::google::protobuf::Message /* @@protoc_inserti
                &_ActiveActorsCount_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    45;
+    50;
 
   void Swap(ActiveActorsCount* other);
   friend void swap(ActiveActorsCount& a, ActiveActorsCount& b) {
@@ -4943,7 +5497,7 @@ class RegisteredComponents : public ::google::protobuf::Message /* @@protoc_inse
                &_RegisteredComponents_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    51;
 
   void Swap(RegisteredComponents* other);
   friend void swap(RegisteredComponents& a, RegisteredComponents& b) {
@@ -5084,7 +5638,7 @@ class SetMetadataRequest : public ::google::protobuf::Message /* @@protoc_insert
                &_SetMetadataRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    52;
 
   void Swap(SetMetadataRequest* other);
   friend void swap(SetMetadataRequest& a, SetMetadataRequest& b) {
@@ -5170,6 +5724,566 @@ class SetMetadataRequest : public ::google::protobuf::Message /* @@protoc_insert
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::ArenaStringPtr key_;
   ::google::protobuf::internal::ArenaStringPtr value_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class GetConfigurationRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GetConfigurationRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GetConfigurationRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GetConfigurationRequest_MetadataEntry_DoNotUse();
+  GetConfigurationRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GetConfigurationRequest_MetadataEntry_DoNotUse& other);
+  static const GetConfigurationRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GetConfigurationRequest_MetadataEntry_DoNotUse*>(&_GetConfigurationRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class GetConfigurationRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.GetConfigurationRequest) */ {
+ public:
+  GetConfigurationRequest();
+  virtual ~GetConfigurationRequest();
+
+  GetConfigurationRequest(const GetConfigurationRequest& from);
+
+  inline GetConfigurationRequest& operator=(const GetConfigurationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GetConfigurationRequest(GetConfigurationRequest&& from) noexcept
+    : GetConfigurationRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline GetConfigurationRequest& operator=(GetConfigurationRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GetConfigurationRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GetConfigurationRequest* internal_default_instance() {
+    return reinterpret_cast<const GetConfigurationRequest*>(
+               &_GetConfigurationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    54;
+
+  void Swap(GetConfigurationRequest* other);
+  friend void swap(GetConfigurationRequest& a, GetConfigurationRequest& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GetConfigurationRequest* New() const final {
+    return CreateMaybeMessage<GetConfigurationRequest>(NULL);
+  }
+
+  GetConfigurationRequest* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<GetConfigurationRequest>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const GetConfigurationRequest& from);
+  void MergeFrom(const GetConfigurationRequest& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GetConfigurationRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // repeated string keys = 2;
+  int keys_size() const;
+  void clear_keys();
+  static const int kKeysFieldNumber = 2;
+  const ::std::string& keys(int index) const;
+  ::std::string* mutable_keys(int index);
+  void set_keys(int index, const ::std::string& value);
+  #if LANG_CXX11
+  void set_keys(int index, ::std::string&& value);
+  #endif
+  void set_keys(int index, const char* value);
+  void set_keys(int index, const char* value, size_t size);
+  ::std::string* add_keys();
+  void add_keys(const ::std::string& value);
+  #if LANG_CXX11
+  void add_keys(::std::string&& value);
+  #endif
+  void add_keys(const char* value);
+  void add_keys(const char* value, size_t size);
+  const ::google::protobuf::RepeatedPtrField< ::std::string>& keys() const;
+  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_keys();
+
+  // map<string, string> metadata = 3;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 3;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
+
+  // string store_name = 1;
+  void clear_store_name();
+  static const int kStoreNameFieldNumber = 1;
+  const ::std::string& store_name() const;
+  void set_store_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_store_name(::std::string&& value);
+  #endif
+  void set_store_name(const char* value);
+  void set_store_name(const char* value, size_t size);
+  ::std::string* mutable_store_name();
+  ::std::string* release_store_name();
+  void set_allocated_store_name(::std::string* store_name);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.GetConfigurationRequest)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> keys_;
+  ::google::protobuf::internal::MapField<
+      GetConfigurationRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
+  ::google::protobuf::internal::ArenaStringPtr store_name_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class GetConfigurationResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.GetConfigurationResponse) */ {
+ public:
+  GetConfigurationResponse();
+  virtual ~GetConfigurationResponse();
+
+  GetConfigurationResponse(const GetConfigurationResponse& from);
+
+  inline GetConfigurationResponse& operator=(const GetConfigurationResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GetConfigurationResponse(GetConfigurationResponse&& from) noexcept
+    : GetConfigurationResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline GetConfigurationResponse& operator=(GetConfigurationResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GetConfigurationResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GetConfigurationResponse* internal_default_instance() {
+    return reinterpret_cast<const GetConfigurationResponse*>(
+               &_GetConfigurationResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    55;
+
+  void Swap(GetConfigurationResponse* other);
+  friend void swap(GetConfigurationResponse& a, GetConfigurationResponse& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GetConfigurationResponse* New() const final {
+    return CreateMaybeMessage<GetConfigurationResponse>(NULL);
+  }
+
+  GetConfigurationResponse* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<GetConfigurationResponse>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const GetConfigurationResponse& from);
+  void MergeFrom(const GetConfigurationResponse& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(GetConfigurationResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  int items_size() const;
+  void clear_items();
+  static const int kItemsFieldNumber = 1;
+  ::dapr::proto::common::v1::ConfigurationItem* mutable_items(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >*
+      mutable_items();
+  const ::dapr::proto::common::v1::ConfigurationItem& items(int index) const;
+  ::dapr::proto::common::v1::ConfigurationItem* add_items();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >&
+      items() const;
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.GetConfigurationResponse)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem > items_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class SubscribeConfigurationRequest_MetadataEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<SubscribeConfigurationRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<SubscribeConfigurationRequest_MetadataEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  SubscribeConfigurationRequest_MetadataEntry_DoNotUse();
+  SubscribeConfigurationRequest_MetadataEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const SubscribeConfigurationRequest_MetadataEntry_DoNotUse& other);
+  static const SubscribeConfigurationRequest_MetadataEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const SubscribeConfigurationRequest_MetadataEntry_DoNotUse*>(&_SubscribeConfigurationRequest_MetadataEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) final;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class SubscribeConfigurationRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.SubscribeConfigurationRequest) */ {
+ public:
+  SubscribeConfigurationRequest();
+  virtual ~SubscribeConfigurationRequest();
+
+  SubscribeConfigurationRequest(const SubscribeConfigurationRequest& from);
+
+  inline SubscribeConfigurationRequest& operator=(const SubscribeConfigurationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  SubscribeConfigurationRequest(SubscribeConfigurationRequest&& from) noexcept
+    : SubscribeConfigurationRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeConfigurationRequest& operator=(SubscribeConfigurationRequest&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SubscribeConfigurationRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SubscribeConfigurationRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeConfigurationRequest*>(
+               &_SubscribeConfigurationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    57;
+
+  void Swap(SubscribeConfigurationRequest* other);
+  friend void swap(SubscribeConfigurationRequest& a, SubscribeConfigurationRequest& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeConfigurationRequest* New() const final {
+    return CreateMaybeMessage<SubscribeConfigurationRequest>(NULL);
+  }
+
+  SubscribeConfigurationRequest* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeConfigurationRequest>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const SubscribeConfigurationRequest& from);
+  void MergeFrom(const SubscribeConfigurationRequest& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeConfigurationRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // repeated string keys = 2;
+  int keys_size() const;
+  void clear_keys();
+  static const int kKeysFieldNumber = 2;
+  const ::std::string& keys(int index) const;
+  ::std::string* mutable_keys(int index);
+  void set_keys(int index, const ::std::string& value);
+  #if LANG_CXX11
+  void set_keys(int index, ::std::string&& value);
+  #endif
+  void set_keys(int index, const char* value);
+  void set_keys(int index, const char* value, size_t size);
+  ::std::string* add_keys();
+  void add_keys(const ::std::string& value);
+  #if LANG_CXX11
+  void add_keys(::std::string&& value);
+  #endif
+  void add_keys(const char* value);
+  void add_keys(const char* value, size_t size);
+  const ::google::protobuf::RepeatedPtrField< ::std::string>& keys() const;
+  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_keys();
+
+  // map<string, string> metadata = 3;
+  int metadata_size() const;
+  void clear_metadata();
+  static const int kMetadataFieldNumber = 3;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      metadata() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_metadata();
+
+  // string store_name = 1;
+  void clear_store_name();
+  static const int kStoreNameFieldNumber = 1;
+  const ::std::string& store_name() const;
+  void set_store_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_store_name(::std::string&& value);
+  #endif
+  void set_store_name(const char* value);
+  void set_store_name(const char* value, size_t size);
+  ::std::string* mutable_store_name();
+  ::std::string* release_store_name();
+  void set_allocated_store_name(::std::string* store_name);
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.SubscribeConfigurationRequest)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> keys_;
+  ::google::protobuf::internal::MapField<
+      SubscribeConfigurationRequest_MetadataEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > metadata_;
+  ::google::protobuf::internal::ArenaStringPtr store_name_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class SubscribeConfigurationResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:dapr.proto.runtime.v1.SubscribeConfigurationResponse) */ {
+ public:
+  SubscribeConfigurationResponse();
+  virtual ~SubscribeConfigurationResponse();
+
+  SubscribeConfigurationResponse(const SubscribeConfigurationResponse& from);
+
+  inline SubscribeConfigurationResponse& operator=(const SubscribeConfigurationResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  SubscribeConfigurationResponse(SubscribeConfigurationResponse&& from) noexcept
+    : SubscribeConfigurationResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SubscribeConfigurationResponse& operator=(SubscribeConfigurationResponse&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SubscribeConfigurationResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const SubscribeConfigurationResponse* internal_default_instance() {
+    return reinterpret_cast<const SubscribeConfigurationResponse*>(
+               &_SubscribeConfigurationResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    58;
+
+  void Swap(SubscribeConfigurationResponse* other);
+  friend void swap(SubscribeConfigurationResponse& a, SubscribeConfigurationResponse& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SubscribeConfigurationResponse* New() const final {
+    return CreateMaybeMessage<SubscribeConfigurationResponse>(NULL);
+  }
+
+  SubscribeConfigurationResponse* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<SubscribeConfigurationResponse>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const SubscribeConfigurationResponse& from);
+  void MergeFrom(const SubscribeConfigurationResponse& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SubscribeConfigurationResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+  int items_size() const;
+  void clear_items();
+  static const int kItemsFieldNumber = 1;
+  ::dapr::proto::common::v1::ConfigurationItem* mutable_items(int index);
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >*
+      mutable_items();
+  const ::dapr::proto::common::v1::ConfigurationItem& items(int index) const;
+  ::dapr::proto::common::v1::ConfigurationItem* add_items();
+  const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >&
+      items() const;
+
+  // @@protoc_insertion_point(class_scope:dapr.proto.runtime.v1.SubscribeConfigurationResponse)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem > items_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_dapr_2fproto_2fruntime_2fv1_2fdapr_2eproto::TableStruct;
 };
@@ -6381,6 +7495,459 @@ inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::St
 SaveStateRequest::states() const {
   // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.SaveStateRequest.states)
   return states_;
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// QueryStateRequest
+
+// string store_name = 1;
+inline void QueryStateRequest::clear_store_name() {
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateRequest::store_name() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+  return store_name_.GetNoArena();
+}
+inline void QueryStateRequest::set_store_name(const ::std::string& value) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+}
+#if LANG_CXX11
+inline void QueryStateRequest::set_store_name(::std::string&& value) {
+  
+  store_name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+}
+#endif
+inline void QueryStateRequest::set_store_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+}
+inline void QueryStateRequest::set_store_name(const char* value, size_t size) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+}
+inline ::std::string* QueryStateRequest::mutable_store_name() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+  return store_name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateRequest::release_store_name() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+  
+  return store_name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateRequest::set_allocated_store_name(::std::string* store_name) {
+  if (store_name != NULL) {
+    
+  } else {
+    
+  }
+  store_name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), store_name);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateRequest.store_name)
+}
+
+// string query = 2;
+inline void QueryStateRequest::clear_query() {
+  query_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateRequest::query() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateRequest.query)
+  return query_.GetNoArena();
+}
+inline void QueryStateRequest::set_query(const ::std::string& value) {
+  
+  query_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateRequest.query)
+}
+#if LANG_CXX11
+inline void QueryStateRequest::set_query(::std::string&& value) {
+  
+  query_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateRequest.query)
+}
+#endif
+inline void QueryStateRequest::set_query(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  query_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateRequest.query)
+}
+inline void QueryStateRequest::set_query(const char* value, size_t size) {
+  
+  query_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateRequest.query)
+}
+inline ::std::string* QueryStateRequest::mutable_query() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateRequest.query)
+  return query_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateRequest::release_query() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateRequest.query)
+  
+  return query_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateRequest::set_allocated_query(::std::string* query) {
+  if (query != NULL) {
+    
+  } else {
+    
+  }
+  query_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), query);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateRequest.query)
+}
+
+// map<string, string> metadata = 3;
+inline int QueryStateRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void QueryStateRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+QueryStateRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.QueryStateRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+QueryStateRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.QueryStateRequest.metadata)
+  return metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// QueryStateItem
+
+// string key = 1;
+inline void QueryStateItem::clear_key() {
+  key_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateItem::key() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateItem.key)
+  return key_.GetNoArena();
+}
+inline void QueryStateItem::set_key(const ::std::string& value) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateItem.key)
+}
+#if LANG_CXX11
+inline void QueryStateItem::set_key(::std::string&& value) {
+  
+  key_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateItem.key)
+}
+#endif
+inline void QueryStateItem::set_key(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateItem.key)
+}
+inline void QueryStateItem::set_key(const char* value, size_t size) {
+  
+  key_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateItem.key)
+}
+inline ::std::string* QueryStateItem::mutable_key() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateItem.key)
+  return key_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateItem::release_key() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateItem.key)
+  
+  return key_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateItem::set_allocated_key(::std::string* key) {
+  if (key != NULL) {
+    
+  } else {
+    
+  }
+  key_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), key);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateItem.key)
+}
+
+// bytes data = 2;
+inline void QueryStateItem::clear_data() {
+  data_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateItem::data() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateItem.data)
+  return data_.GetNoArena();
+}
+inline void QueryStateItem::set_data(const ::std::string& value) {
+  
+  data_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateItem.data)
+}
+#if LANG_CXX11
+inline void QueryStateItem::set_data(::std::string&& value) {
+  
+  data_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateItem.data)
+}
+#endif
+inline void QueryStateItem::set_data(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  data_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateItem.data)
+}
+inline void QueryStateItem::set_data(const void* value, size_t size) {
+  
+  data_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateItem.data)
+}
+inline ::std::string* QueryStateItem::mutable_data() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateItem.data)
+  return data_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateItem::release_data() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateItem.data)
+  
+  return data_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateItem::set_allocated_data(::std::string* data) {
+  if (data != NULL) {
+    
+  } else {
+    
+  }
+  data_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), data);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateItem.data)
+}
+
+// string etag = 3;
+inline void QueryStateItem::clear_etag() {
+  etag_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateItem::etag() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateItem.etag)
+  return etag_.GetNoArena();
+}
+inline void QueryStateItem::set_etag(const ::std::string& value) {
+  
+  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateItem.etag)
+}
+#if LANG_CXX11
+inline void QueryStateItem::set_etag(::std::string&& value) {
+  
+  etag_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateItem.etag)
+}
+#endif
+inline void QueryStateItem::set_etag(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateItem.etag)
+}
+inline void QueryStateItem::set_etag(const char* value, size_t size) {
+  
+  etag_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateItem.etag)
+}
+inline ::std::string* QueryStateItem::mutable_etag() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateItem.etag)
+  return etag_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateItem::release_etag() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateItem.etag)
+  
+  return etag_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateItem::set_allocated_etag(::std::string* etag) {
+  if (etag != NULL) {
+    
+  } else {
+    
+  }
+  etag_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), etag);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateItem.etag)
+}
+
+// string error = 4;
+inline void QueryStateItem::clear_error() {
+  error_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateItem::error() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateItem.error)
+  return error_.GetNoArena();
+}
+inline void QueryStateItem::set_error(const ::std::string& value) {
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateItem.error)
+}
+#if LANG_CXX11
+inline void QueryStateItem::set_error(::std::string&& value) {
+  
+  error_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateItem.error)
+}
+#endif
+inline void QueryStateItem::set_error(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateItem.error)
+}
+inline void QueryStateItem::set_error(const char* value, size_t size) {
+  
+  error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateItem.error)
+}
+inline ::std::string* QueryStateItem::mutable_error() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateItem.error)
+  return error_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateItem::release_error() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateItem.error)
+  
+  return error_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateItem::set_allocated_error(::std::string* error) {
+  if (error != NULL) {
+    
+  } else {
+    
+  }
+  error_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), error);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateItem.error)
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// QueryStateResponse
+
+// repeated .dapr.proto.runtime.v1.QueryStateItem results = 1;
+inline int QueryStateResponse::results_size() const {
+  return results_.size();
+}
+inline void QueryStateResponse::clear_results() {
+  results_.Clear();
+}
+inline ::dapr::proto::runtime::v1::QueryStateItem* QueryStateResponse::mutable_results(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateResponse.results)
+  return results_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::QueryStateItem >*
+QueryStateResponse::mutable_results() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.QueryStateResponse.results)
+  return &results_;
+}
+inline const ::dapr::proto::runtime::v1::QueryStateItem& QueryStateResponse::results(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateResponse.results)
+  return results_.Get(index);
+}
+inline ::dapr::proto::runtime::v1::QueryStateItem* QueryStateResponse::add_results() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.QueryStateResponse.results)
+  return results_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::runtime::v1::QueryStateItem >&
+QueryStateResponse::results() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.QueryStateResponse.results)
+  return results_;
+}
+
+// string token = 2;
+inline void QueryStateResponse::clear_token() {
+  token_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& QueryStateResponse::token() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.QueryStateResponse.token)
+  return token_.GetNoArena();
+}
+inline void QueryStateResponse::set_token(const ::std::string& value) {
+  
+  token_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.QueryStateResponse.token)
+}
+#if LANG_CXX11
+inline void QueryStateResponse::set_token(::std::string&& value) {
+  
+  token_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.QueryStateResponse.token)
+}
+#endif
+inline void QueryStateResponse::set_token(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  token_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.QueryStateResponse.token)
+}
+inline void QueryStateResponse::set_token(const char* value, size_t size) {
+  
+  token_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.QueryStateResponse.token)
+}
+inline ::std::string* QueryStateResponse::mutable_token() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.QueryStateResponse.token)
+  return token_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* QueryStateResponse::release_token() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.QueryStateResponse.token)
+  
+  return token_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void QueryStateResponse::set_allocated_token(::std::string* token) {
+  if (token != NULL) {
+    
+  } else {
+    
+  }
+  token_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), token);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.QueryStateResponse.token)
+}
+
+// map<string, string> metadata = 3;
+inline int QueryStateResponse::metadata_size() const {
+  return metadata_.size();
+}
+inline void QueryStateResponse::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+QueryStateResponse::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.QueryStateResponse.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+QueryStateResponse::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.QueryStateResponse.metadata)
+  return metadata_.MutableMap();
 }
 
 // -------------------------------------------------------------------
@@ -7745,6 +9312,59 @@ inline void RegisterActorTimerRequest::set_allocated_data(::std::string* data) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisterActorTimerRequest.data)
 }
 
+// string ttl = 8;
+inline void RegisterActorTimerRequest::clear_ttl() {
+  ttl_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RegisterActorTimerRequest::ttl() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+  return ttl_.GetNoArena();
+}
+inline void RegisterActorTimerRequest::set_ttl(const ::std::string& value) {
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+}
+#if LANG_CXX11
+inline void RegisterActorTimerRequest::set_ttl(::std::string&& value) {
+  
+  ttl_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+}
+#endif
+inline void RegisterActorTimerRequest::set_ttl(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+}
+inline void RegisterActorTimerRequest::set_ttl(const char* value, size_t size) {
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+}
+inline ::std::string* RegisterActorTimerRequest::mutable_ttl() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+  return ttl_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RegisterActorTimerRequest::release_ttl() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+  
+  return ttl_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RegisterActorTimerRequest::set_allocated_ttl(::std::string* ttl) {
+  if (ttl != NULL) {
+    
+  } else {
+    
+  }
+  ttl_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ttl);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisterActorTimerRequest.ttl)
+}
+
 // -------------------------------------------------------------------
 
 // UnregisterActorTimerRequest
@@ -8228,6 +9848,59 @@ inline void RegisterActorReminderRequest::set_allocated_data(::std::string* data
   }
   data_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), data);
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisterActorReminderRequest.data)
+}
+
+// string ttl = 7;
+inline void RegisterActorReminderRequest::clear_ttl() {
+  ttl_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RegisterActorReminderRequest::ttl() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+  return ttl_.GetNoArena();
+}
+inline void RegisterActorReminderRequest::set_ttl(const ::std::string& value) {
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+}
+#if LANG_CXX11
+inline void RegisterActorReminderRequest::set_ttl(::std::string&& value) {
+  
+  ttl_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+}
+#endif
+inline void RegisterActorReminderRequest::set_ttl(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+}
+inline void RegisterActorReminderRequest::set_ttl(const char* value, size_t size) {
+  
+  ttl_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+}
+inline ::std::string* RegisterActorReminderRequest::mutable_ttl() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+  return ttl_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RegisterActorReminderRequest::release_ttl() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
+  
+  return ttl_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RegisterActorReminderRequest::set_allocated_ttl(::std::string* ttl) {
+  if (ttl != NULL) {
+    
+  } else {
+    
+  }
+  ttl_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ttl);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.RegisterActorReminderRequest.ttl)
 }
 
 // -------------------------------------------------------------------
@@ -9665,9 +11338,385 @@ inline void SetMetadataRequest::set_allocated_value(::std::string* value) {
   // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.SetMetadataRequest.value)
 }
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// GetConfigurationRequest
+
+// string store_name = 1;
+inline void GetConfigurationRequest::clear_store_name() {
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GetConfigurationRequest::store_name() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+  return store_name_.GetNoArena();
+}
+inline void GetConfigurationRequest::set_store_name(const ::std::string& value) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+}
+#if LANG_CXX11
+inline void GetConfigurationRequest::set_store_name(::std::string&& value) {
+  
+  store_name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+}
+#endif
+inline void GetConfigurationRequest::set_store_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+}
+inline void GetConfigurationRequest::set_store_name(const char* value, size_t size) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+}
+inline ::std::string* GetConfigurationRequest::mutable_store_name() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+  return store_name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GetConfigurationRequest::release_store_name() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+  
+  return store_name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GetConfigurationRequest::set_allocated_store_name(::std::string* store_name) {
+  if (store_name != NULL) {
+    
+  } else {
+    
+  }
+  store_name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), store_name);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.GetConfigurationRequest.store_name)
+}
+
+// repeated string keys = 2;
+inline int GetConfigurationRequest::keys_size() const {
+  return keys_.size();
+}
+inline void GetConfigurationRequest::clear_keys() {
+  keys_.Clear();
+}
+inline const ::std::string& GetConfigurationRequest::keys(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  return keys_.Get(index);
+}
+inline ::std::string* GetConfigurationRequest::mutable_keys(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  return keys_.Mutable(index);
+}
+inline void GetConfigurationRequest::set_keys(int index, const ::std::string& value) {
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  keys_.Mutable(index)->assign(value);
+}
+#if LANG_CXX11
+inline void GetConfigurationRequest::set_keys(int index, ::std::string&& value) {
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  keys_.Mutable(index)->assign(std::move(value));
+}
+#endif
+inline void GetConfigurationRequest::set_keys(int index, const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  keys_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+inline void GetConfigurationRequest::set_keys(int index, const char* value, size_t size) {
+  keys_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+inline ::std::string* GetConfigurationRequest::add_keys() {
+  // @@protoc_insertion_point(field_add_mutable:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  return keys_.Add();
+}
+inline void GetConfigurationRequest::add_keys(const ::std::string& value) {
+  keys_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+#if LANG_CXX11
+inline void GetConfigurationRequest::add_keys(::std::string&& value) {
+  keys_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+#endif
+inline void GetConfigurationRequest::add_keys(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  keys_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+inline void GetConfigurationRequest::add_keys(const char* value, size_t size) {
+  keys_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+GetConfigurationRequest::keys() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  return keys_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+GetConfigurationRequest::mutable_keys() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.GetConfigurationRequest.keys)
+  return &keys_;
+}
+
+// map<string, string> metadata = 3;
+inline int GetConfigurationRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void GetConfigurationRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GetConfigurationRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.GetConfigurationRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GetConfigurationRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.GetConfigurationRequest.metadata)
+  return metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// GetConfigurationResponse
+
+// repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+inline int GetConfigurationResponse::items_size() const {
+  return items_.size();
+}
+inline ::dapr::proto::common::v1::ConfigurationItem* GetConfigurationResponse::mutable_items(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.GetConfigurationResponse.items)
+  return items_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >*
+GetConfigurationResponse::mutable_items() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.GetConfigurationResponse.items)
+  return &items_;
+}
+inline const ::dapr::proto::common::v1::ConfigurationItem& GetConfigurationResponse::items(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.GetConfigurationResponse.items)
+  return items_.Get(index);
+}
+inline ::dapr::proto::common::v1::ConfigurationItem* GetConfigurationResponse::add_items() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.GetConfigurationResponse.items)
+  return items_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >&
+GetConfigurationResponse::items() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.GetConfigurationResponse.items)
+  return items_;
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// SubscribeConfigurationRequest
+
+// string store_name = 1;
+inline void SubscribeConfigurationRequest::clear_store_name() {
+  store_name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& SubscribeConfigurationRequest::store_name() const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+  return store_name_.GetNoArena();
+}
+inline void SubscribeConfigurationRequest::set_store_name(const ::std::string& value) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+}
+#if LANG_CXX11
+inline void SubscribeConfigurationRequest::set_store_name(::std::string&& value) {
+  
+  store_name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+}
+#endif
+inline void SubscribeConfigurationRequest::set_store_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+}
+inline void SubscribeConfigurationRequest::set_store_name(const char* value, size_t size) {
+  
+  store_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+}
+inline ::std::string* SubscribeConfigurationRequest::mutable_store_name() {
+  
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+  return store_name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* SubscribeConfigurationRequest::release_store_name() {
+  // @@protoc_insertion_point(field_release:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+  
+  return store_name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void SubscribeConfigurationRequest::set_allocated_store_name(::std::string* store_name) {
+  if (store_name != NULL) {
+    
+  } else {
+    
+  }
+  store_name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), store_name);
+  // @@protoc_insertion_point(field_set_allocated:dapr.proto.runtime.v1.SubscribeConfigurationRequest.store_name)
+}
+
+// repeated string keys = 2;
+inline int SubscribeConfigurationRequest::keys_size() const {
+  return keys_.size();
+}
+inline void SubscribeConfigurationRequest::clear_keys() {
+  keys_.Clear();
+}
+inline const ::std::string& SubscribeConfigurationRequest::keys(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  return keys_.Get(index);
+}
+inline ::std::string* SubscribeConfigurationRequest::mutable_keys(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  return keys_.Mutable(index);
+}
+inline void SubscribeConfigurationRequest::set_keys(int index, const ::std::string& value) {
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  keys_.Mutable(index)->assign(value);
+}
+#if LANG_CXX11
+inline void SubscribeConfigurationRequest::set_keys(int index, ::std::string&& value) {
+  // @@protoc_insertion_point(field_set:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  keys_.Mutable(index)->assign(std::move(value));
+}
+#endif
+inline void SubscribeConfigurationRequest::set_keys(int index, const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  keys_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+inline void SubscribeConfigurationRequest::set_keys(int index, const char* value, size_t size) {
+  keys_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+inline ::std::string* SubscribeConfigurationRequest::add_keys() {
+  // @@protoc_insertion_point(field_add_mutable:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  return keys_.Add();
+}
+inline void SubscribeConfigurationRequest::add_keys(const ::std::string& value) {
+  keys_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+#if LANG_CXX11
+inline void SubscribeConfigurationRequest::add_keys(::std::string&& value) {
+  keys_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+#endif
+inline void SubscribeConfigurationRequest::add_keys(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  keys_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+inline void SubscribeConfigurationRequest::add_keys(const char* value, size_t size) {
+  keys_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+SubscribeConfigurationRequest::keys() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  return keys_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+SubscribeConfigurationRequest::mutable_keys() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.SubscribeConfigurationRequest.keys)
+  return &keys_;
+}
+
+// map<string, string> metadata = 3;
+inline int SubscribeConfigurationRequest::metadata_size() const {
+  return metadata_.size();
+}
+inline void SubscribeConfigurationRequest::clear_metadata() {
+  metadata_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+SubscribeConfigurationRequest::metadata() const {
+  // @@protoc_insertion_point(field_map:dapr.proto.runtime.v1.SubscribeConfigurationRequest.metadata)
+  return metadata_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+SubscribeConfigurationRequest::mutable_metadata() {
+  // @@protoc_insertion_point(field_mutable_map:dapr.proto.runtime.v1.SubscribeConfigurationRequest.metadata)
+  return metadata_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeConfigurationResponse
+
+// repeated .dapr.proto.common.v1.ConfigurationItem items = 1;
+inline int SubscribeConfigurationResponse::items_size() const {
+  return items_.size();
+}
+inline ::dapr::proto::common::v1::ConfigurationItem* SubscribeConfigurationResponse::mutable_items(int index) {
+  // @@protoc_insertion_point(field_mutable:dapr.proto.runtime.v1.SubscribeConfigurationResponse.items)
+  return items_.Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >*
+SubscribeConfigurationResponse::mutable_items() {
+  // @@protoc_insertion_point(field_mutable_list:dapr.proto.runtime.v1.SubscribeConfigurationResponse.items)
+  return &items_;
+}
+inline const ::dapr::proto::common::v1::ConfigurationItem& SubscribeConfigurationResponse::items(int index) const {
+  // @@protoc_insertion_point(field_get:dapr.proto.runtime.v1.SubscribeConfigurationResponse.items)
+  return items_.Get(index);
+}
+inline ::dapr::proto::common::v1::ConfigurationItem* SubscribeConfigurationResponse::add_items() {
+  // @@protoc_insertion_point(field_add:dapr.proto.runtime.v1.SubscribeConfigurationResponse.items)
+  return items_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::dapr::proto::common::v1::ConfigurationItem >&
+SubscribeConfigurationResponse::items() const {
+  // @@protoc_insertion_point(field_list:dapr.proto.runtime.v1.SubscribeConfigurationResponse.items)
+  return items_;
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Validated in GitHub Codespaces (using updated Dev Container) by running:

```bash
dapr init --runtime-version 1.5.0-rc.2
cd examples/echo_app/ && mm.py README.md && echo SUCCESS
```

Result:

```bash
Running shell 'bash -c' with command: `make`
Running shell 'bash -c' with command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
Running shell 'bash -c' with command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
Running shell 'bash -c' with command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
Step: Build example
        command: `make`
        return_code: 0
        duration_seconds: 0.932
        Expected stdout (output_match_mode: exact):
        Actual stdout:
                g++ ../../src/dapr/proto/common/v1/common.pb.o ../../src/dapr/proto/runtime/v1/dapr.pb.o ../../src/dapr/proto/runtime/v1/dapr.grpc.pb.o ../../src/dapr/proto/runtime/v1/appcallback.pb.o ../../src/dapr/proto/runtime/v1/appcallback.grpc.pb.o echo_app_server_impl.o echo_app.o -L/usr/local/lib `pkg-config --libs protobuf grpc++` -pthread -Wl,--no-as-needed -lgrpc++_reflection -Wl,--as-needed -ldl -o echo_app

        Expected stderr (output_match_mode: exact):
        Actual stderr:

Step: Run callee
        command: `dapr run --app-id callee --app-protocol grpc --app-port 6000  ./echo_app callee 6000`
        return_code: 0
        duration_seconds: 10.2
        Expected stdout (output_match_mode: exact):
                == APP == OnInvoke() is called
                == APP == Got the message: hello dapr
        Actual stdout:
                ℹ️  Starting Dapr with id callee. HTTP Port: 36507. gRPC Port: 37969
                == APP == Start echo app (callee) - callee: , Dapr gRPC Port: 37969, Echo App Port: 6000
                == APP == Server listening on 127.0.0.1:6000
                time="2021-11-08T22:25:25.179696286Z" level=info msg="starting Dapr Runtime -- version 1.5.0-rc.2 -- commit cc597307f9b3abf8445fcb9b296a59a356aa095e" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.179726086Z" level=info msg="log level set to: info" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.179823387Z" level=info msg="metrics server started on :37127/" app_id=callee instance=codespaces_32adc1 scope=dapr.metrics type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.180245092Z" level=info msg="standalone mode configured" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.180265093Z" level=info msg="app id: callee" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.180410694Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.181929313Z" level=info msg="local service entry announced: callee -> 172.16.5.4:42643" app_id=callee instance=codespaces_32adc1 scope=dapr.contrib type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.181979713Z" level=info msg="Initialized name resolution to mdns" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.182063814Z" level=info msg="loading components" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.184359742Z" level=info msg="component loaded. name: pubsub, type: pubsub.redis/v1" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.184465443Z" level=info msg="waiting for all outstanding components to be processed" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185113951Z" level=info msg="component loaded. name: statestore, type: state.redis/v1" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185144652Z" level=info msg="all outstanding components processed" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185195852Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.grpc.api type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185212252Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.grpc.api type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185263753Z" level=info msg="API gRPC server is running on port 37969" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185437955Z" level=info msg="enabled metrics http middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.http type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185454555Z" level=info msg="enabled tracing http middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.http type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185539856Z" level=info msg="http server is running on port 36507" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185553857Z" level=info msg="The request body size parameter is: 4" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185606357Z" level=info msg="enabled gRPC tracing middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.grpc.internal type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185627657Z" level=info msg="enabled gRPC metrics middleware" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.grpc.internal type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185646158Z" level=info msg="internal gRPC server is running on port 42643" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.185653958Z" level=info msg="application protocol: grpc. waiting on port 6000.  This will block until the app is listening on that port." app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.186000162Z" level=info msg="application discovered on port 6000" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.186228765Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.actor type=log ver=1.5.0-rc.2
                == APP == ListTopicSubscriptions() is called
                time="2021-11-08T22:25:25.187359078Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 7.1075859999999995ms" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:25.201887553Z" level=info msg="placement tables updated, version: 0" app_id=callee instance=codespaces_32adc1 scope=dapr.runtime.actor.internal.placement type=log ver=1.5.0-rc.2
                ℹ️  Updating metadata for app command: ./echo_app callee 6000
                ✅  You're up and running! Both Dapr and your app logs will appear here.

                == APP == OnInvoke() is called
                == APP == Got the message: hello dapr
                ℹ️  
                terminated signal received: shutting down
                ✅  Exited Dapr successfully
                ✅  Exited App successfully

        Expected stderr (output_match_mode: exact):
        Actual stderr:
                2021/11/08 22:25:25 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined

Step: Run caller
        command: `dapr run --app-id echo_app --app-protocol grpc --app-port 6100 ./echo_app caller 6100 callee`
        return_code: 0
        duration_seconds: 5.09
        Expected stdout (output_match_mode: exact):
                == APP == Call echo method to callee
                == APP == Received [ack : hello dapr] from callee
        Actual stdout:
                ℹ️  Starting Dapr with id echo_app. HTTP Port: 45511. gRPC Port: 46481
                == APP == Start echo app (caller) - callee: callee, Dapr gRPC Port: 46481, Echo App Port: 6100
                == APP == Server listening on 127.0.0.1:6100
                time="2021-11-08T22:25:30.184263819Z" level=info msg="starting Dapr Runtime -- version 1.5.0-rc.2 -- commit cc597307f9b3abf8445fcb9b296a59a356aa095e" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.184292419Z" level=info msg="log level set to: info" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.18437092Z" level=info msg="metrics server started on :36093/" app_id=echo_app instance=codespaces_32adc1 scope=dapr.metrics type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.184828925Z" level=info msg="standalone mode configured" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.184848326Z" level=info msg="app id: echo_app" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.184978227Z" level=info msg="mTLS is disabled. Skipping certificate request and tls validation" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.185300831Z" level=info msg="local service entry announced: echo_app -> 172.16.5.4:35951" app_id=echo_app instance=codespaces_32adc1 scope=dapr.contrib type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.185354332Z" level=info msg="Initialized name resolution to mdns" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.185415032Z" level=info msg="loading components" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.186780849Z" level=info msg="component loaded. name: pubsub, type: pubsub.redis/v1" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.186854849Z" level=info msg="waiting for all outstanding components to be processed" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.187534457Z" level=info msg="component loaded. name: statestore, type: state.redis/v1" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.187566558Z" level=info msg="all outstanding components processed" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.187627759Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.grpc.api type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.187644759Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.grpc.api type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.18770896Z" level=info msg="API gRPC server is running on port 46481" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188396068Z" level=info msg="enabled metrics http middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.http type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188416568Z" level=info msg="enabled tracing http middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.http type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188461568Z" level=info msg="http server is running on port 45511" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188473269Z" level=info msg="The request body size parameter is: 4" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188506369Z" level=info msg="enabled gRPC tracing middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.grpc.internal type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188519569Z" level=info msg="enabled gRPC metrics middleware" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.grpc.internal type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188539769Z" level=info msg="internal gRPC server is running on port 35951" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.18855547Z" level=info msg="application protocol: grpc. waiting on port 6100.  This will block until the app is listening on that port." app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.188837073Z" level=info msg="application discovered on port 6100" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.189010675Z" level=info msg="actor runtime started. actor idle timeout: 1h0m0s. actor scan interval: 30s" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.actor type=log ver=1.5.0-rc.2
                == APP == ListTopicSubscriptions() is called
                time="2021-11-08T22:25:30.191884409Z" level=info msg="dapr initialized. Status: Running. Init Elapsed 7.051883999999999ms" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime type=log ver=1.5.0-rc.2
                time="2021-11-08T22:25:30.192241013Z" level=info msg="placement tables updated, version: 0" app_id=echo_app instance=codespaces_32adc1 scope=dapr.runtime.actor.internal.placement type=log ver=1.5.0-rc.2
                ℹ️  Updating metadata for app command: ./echo_app caller 6100 callee
                ✅  You're up and running! Both Dapr and your app logs will appear here.

                == APP == Connecting to 127.0.0.1:46481...
                == APP == Call echo method to callee
                == APP == Received [ack : hello dapr] from callee
                ℹ️  
                terminated signal received: shutting down
                ✅  Exited Dapr successfully
                ✅  Exited App successfully

        Expected stderr (output_match_mode: exact):
        Actual stderr:
                2021/11/08 22:25:30 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined

Step: Shutdown dapr
        command: `dapr stop --app-id echo_app
dapr stop --app-id callee`
        return_code: 0
        duration_seconds: 0.156
        Expected stdout (output_match_mode: exact):
                ✅  app stopped successfully: echo_app
                ✅  app stopped successfully: callee
        Actual stdout:
                ✅  app stopped successfully: echo_app
                ✅  app stopped successfully: callee

        Expected stderr (output_match_mode: exact):
        Actual stderr:


SUCCESS
```